### PR TITLE
Customizable dashboard + History overhaul + action consolidation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,28 @@ delete.html
 **/build/eucplanet_*
 
 test-out/
+
+# Debug session dumps at repo root (uiautomator XML dumps, ad-hoc PNGs,
+# settings_dump.bin, ...). Patterns are anchored to the repo root so they
+# don't accidentally match real assets nested in res/ or wear/.
+/[a-z].xml
+/[a-z][0-9].xml
+/u[a-z].xml
+/u-pre.xml
+/u-post.xml
+/po*.xml
+/p[0-9].xml
+/tab[0-9].xml
+/t[0-9].xml
+/m.xml
+/all.xml
+/settings_dump.bin
+/baseline-*.png
+/bug*.png
+/polish*.png
+/step*.png
+/u[0-9]*.png
+/u[0-9]*-s.png
+/u[0-9]*-state*.png
+/v[0-9]*.png
+/v[0-9]*-*.png

--- a/app/src/main/java/com/eried/eucplanet/MainActivity.kt
+++ b/app/src/main/java/com/eried/eucplanet/MainActivity.kt
@@ -24,6 +24,10 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.eried.eucplanet.data.model.AppSettings
 import com.eried.eucplanet.data.repository.SettingsRepository
+import com.eried.eucplanet.diagnostics.DiagnosticsLogger
+import com.eried.eucplanet.diagnostics.ServiceModeOverlay
+import com.eried.eucplanet.diagnostics.ServiceOverlaySnapshot
+import com.eried.eucplanet.diagnostics.ServiceOverlayState
 import com.eried.eucplanet.flic.FlicManager
 import com.eried.eucplanet.service.WheelService
 import com.eried.eucplanet.ui.navigation.NavGraph
@@ -42,6 +46,7 @@ class MainActivity : AppCompatActivity() {
     @Inject lateinit var flicManager: FlicManager
     @Inject lateinit var wearBridge: com.eried.eucplanet.wear.WearBridge
     @Inject lateinit var tripRepository: com.eried.eucplanet.data.repository.TripRepository
+    @Inject lateinit var wheelRepository: com.eried.eucplanet.data.repository.WheelRepository
     @Inject lateinit var incomingShareRepository:
         com.eried.eucplanet.data.repository.IncomingShareRepository
 
@@ -286,6 +291,29 @@ class MainActivity : AppCompatActivity() {
                             },
                             suppressOnPhone = onMapScreen
                         )
+                        // Service-mode debug overlay — opens on volume key
+                        // when DiagnosticsLogger is enabled. Sits at the
+                        // top of the activity composition so it floats
+                        // above every screen (dashboard, settings, etc).
+                        val serviceOpen by ServiceOverlayState.open.collectAsState()
+                        val serviceSnapshot by ServiceOverlayState.snapshot.collectAsState()
+                        val activeSnapshot = serviceSnapshot
+                        if (serviceOpen && activeSnapshot != null) {
+                            ServiceModeOverlay(
+                                snapshot = activeSnapshot,
+                                onFireAction = { key ->
+                                    flicManager.dispatchActionByName(key)
+                                    // Re-snapshot so the action-status
+                                    // readout reflects any toggle that
+                                    // just flipped. Tiny delay would be
+                                    // nicer but the dispatch path itself
+                                    // is async — for now the rider can
+                                    // press Fire again to re-read.
+                                    ServiceOverlayState.refresh(buildServiceOverlaySnapshot())
+                                },
+                                onDismiss = { ServiceOverlayState.dismiss() }
+                            )
+                        }
                     }
                 }
             }
@@ -293,6 +321,19 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
+        // Service-mode override: while diagnostics is enabled, volume keys
+        // open the debug overlay instead of firing their bound action.
+        // The overlay snapshots wheel state + history so the rider can
+        // inspect raw values and fire any catalog action without needing
+        // a Flic button. Service mode is a developer-only state behind
+        // the "Enter" confirmation in the Service Mode dialog.
+        if (DiagnosticsLogger.enabled.value &&
+            (keyCode == KeyEvent.KEYCODE_VOLUME_UP || keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) &&
+            event?.repeatCount == 0
+        ) {
+            ServiceOverlayState.show(buildServiceOverlaySnapshot())
+            return true
+        }
         val s = _settings.value
         if (s != null && s.volumeKeysEnabled &&
             (keyCode == KeyEvent.KEYCODE_VOLUME_UP || keyCode == KeyEvent.KEYCODE_VOLUME_DOWN)
@@ -323,6 +364,14 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onKeyUp(keyCode: Int, event: KeyEvent?): Boolean {
+        // Service mode swallows the up event too, otherwise opening the
+        // overlay on KeyDown would still fire the bound click-action on
+        // KeyUp and the rider would get both the dialog and a HORN beep.
+        if (DiagnosticsLogger.enabled.value &&
+            (keyCode == KeyEvent.KEYCODE_VOLUME_UP || keyCode == KeyEvent.KEYCODE_VOLUME_DOWN)
+        ) {
+            return true
+        }
         val s = _settings.value
         if (s != null && s.volumeKeysEnabled &&
             (keyCode == KeyEvent.KEYCODE_VOLUME_UP || keyCode == KeyEvent.KEYCODE_VOLUME_DOWN)
@@ -336,6 +385,21 @@ class MainActivity : AppCompatActivity() {
             return true
         }
         return super.onKeyUp(keyCode, event)
+    }
+
+    /** Builds a fresh snapshot for the service-mode debug overlay. Called when the overlay opens and after every Fire so the action-status readout updates. */
+    private fun buildServiceOverlaySnapshot(): ServiceOverlaySnapshot {
+        val s = _settings.value
+        return ServiceOverlaySnapshot(
+            wheel = wheelRepository.wheelData.value,
+            history = wheelRepository.fullHistory.value,
+            tripRecording = tripRepository.recording.value,
+            imperialUnits = s?.imperialUnits ?: false,
+            safetyActive = wheelRepository.safetySpeedActive.value,
+            // alarmsMuted not yet surfaced upstream; default false so the
+            // catalog reader returns a defined value rather than throwing.
+            alarmsMuted = false
+        )
     }
 
     private fun requestMissingPermissions() {

--- a/app/src/main/java/com/eried/eucplanet/data/model/ActionCatalog.kt
+++ b/app/src/main/java/com/eried/eucplanet/data/model/ActionCatalog.kt
@@ -1,0 +1,312 @@
+package com.eried.eucplanet.data.model
+
+import androidx.annotation.StringRes
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.material.icons.automirrored.filled.VolumeOff
+import androidx.compose.material.icons.filled.Build
+import androidx.compose.material.icons.filled.Campaign
+import androidx.compose.material.icons.filled.FiberManualRecord
+import androidx.compose.material.icons.filled.FlashlightOn
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Navigation
+import androidx.compose.material.icons.filled.PhotoCamera
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.RecordVoiceOver
+import androidx.compose.material.icons.filled.Restore
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.material.icons.filled.SwapHoriz
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.eried.eucplanet.R
+
+/**
+ * Action layer — single source of truth for every rider-triggerable command.
+ *
+ * Surfaces that can bind an action (Flic, volume keys, watch, dashboard tile,
+ * future alarm-triggers, voice shortcuts, etc.) all query this catalog
+ * instead of maintaining their own list. Adding a new action means adding
+ * one entry to [ActionCatalog.all] — no other file should need to grow a
+ * new branch.
+ *
+ * The discriminator that picks which surfaces an action lands on is the
+ * [ActionSpec.isEyesFreeSafe] flag:
+ *  - Eyes-free safe → bindable on every physical / hands-free surface
+ *    (Flic, volume key, watch, future trigger / alarm-fire).
+ *  - Not eyes-free → only the surfaces where the rider is looking at the
+ *    screen ([ActionSurface.DASHBOARD] / [ActionSurface.VOICE]).
+ *
+ * [ActionSpec.statusReader] returns "is this action's effect currently
+ * active?" so any surface can render an active highlight. Null means the
+ * action has no resting state (HORN, VOICE_ANNOUNCE, RESET_TRIP, etc.).
+ *
+ * [ActionSpec.execute] is the unified executor. Today it's stubbed because
+ * Flic / volume / watch dispatch still goes through `FlicManager`; phase B
+ * migrates those callers to invoke `ActionSpec.execute` directly so the
+ * action layer owns dispatch end-to-end.
+ */
+
+/**
+ * Where an action binding can live. Adding a new surface means defining
+ * what set of actions it accepts (eyes-free vs all) in [ActionCatalog.keysFor].
+ */
+enum class ActionSurface {
+    /** Tap-to-fire grid tile in the dashboard layout editor. */
+    DASHBOARD,
+
+    /** Hardware Flic button. */
+    FLIC,
+
+    /** Phone volume hardware keys. */
+    VOLUME_KEY,
+
+    /** WearOS device button (stem or on-screen tap). */
+    WATCH,
+
+    /** Future: metric-based condition triggers (e.g. "speed > 50 → action"). */
+    TRIGGER,
+
+    /** Future: voice command shortcut ("hey planet, lights on"). */
+    VOICE,
+
+    /** Future: action fired automatically when an alarm condition trips. */
+    ALARM_FIRE
+}
+
+/**
+ * Read-only snapshot of the running app state, passed to
+ * [ActionSpec.statusReader] so it can decide whether the action's effect
+ * is currently active. Carrier-only — no Hilt scope, no flows; the caller
+ * builds a snapshot per dispatch from whatever sources it has.
+ *
+ * Fields are nullable / unknown-default to avoid forcing callers to plumb
+ * every signal. A reader that needs information not provided returns
+ * false (or whatever its safe default is).
+ */
+data class StatusContext(
+    val wheel: WheelData = WheelData(),
+    /** True while [com.eried.eucplanet.data.repository.TripRepository.recording] is on. */
+    val tripRecording: Boolean = false,
+    /** Imperial-unit toggle state from settings. */
+    val imperialUnits: Boolean = false,
+    /** Alarms-muted flag from settings. Not yet wired upstream — defaults false. */
+    val alarmsMuted: Boolean = false,
+    /** True when the wheel is currently in safety / legal mode. */
+    val safetyActive: Boolean = false
+)
+
+/**
+ * Side-effecting context for [ActionSpec.execute]. Phase B fills this in
+ * with real dependencies (wheel repository, voice service, navigation
+ * controller, etc.); today it's a placeholder so the metadata refactor
+ * doesn't have to touch dispatch code.
+ */
+class ActionContext
+
+data class ActionSpec(
+    /** Stable identifier persisted in settings (settings, group definitions, Flic bindings, watch bindings). */
+    val key: String,
+    @StringRes val labelRes: Int,
+    val icon: ImageVector? = null,
+    /**
+     * True when this action is safe to fire without looking at the screen.
+     * Drives which physical-trigger surfaces the action appears on.
+     * Borderline cases (TOGGLE_UNITS, RESET_TRIP, MUTE_ALARMS) are kept
+     * false today because riders typically want visual confirmation.
+     */
+    val isEyesFreeSafe: Boolean = false,
+    /**
+     * Reads the current "is this action's effect currently active?" state.
+     * - Null → one-shot action with no state (HORN, VOICE_ANNOUNCE, MEDIA_*).
+     * - Returns true → surface should render the binding as active (e.g.
+     *   highlight the dashboard tile, fill the watch button icon).
+     * For paired one-direction setters like SAFETY_ON / SAFETY_OFF, the
+     * reader returns true when pressing would be a no-op, so the UI can
+     * disable or de-emphasize the button.
+     */
+    val statusReader: ((StatusContext) -> Boolean)? = null,
+    /**
+     * Fires the action. Stubbed in phase A — dispatch still routes through
+     * FlicManager.executeAction. Phase B migrates that executor here so
+     * every surface uses one path.
+     */
+    val execute: (suspend (ActionContext) -> Unit)? = null
+)
+
+object ActionCatalog {
+
+    val all: List<ActionSpec> = listOf(
+        // ---- Eyes-free safe (Flic / volume / watch / trigger / alarm-fire bindable) ----
+        ActionSpec(
+            key = "HORN",
+            labelRes = R.string.action_chip_horn,
+            icon = Icons.Filled.Campaign,
+            isEyesFreeSafe = true
+        ),
+        ActionSpec(
+            key = "LIGHT_TOGGLE",
+            labelRes = R.string.action_chip_light,
+            icon = Icons.Filled.FlashlightOn,
+            isEyesFreeSafe = true,
+            statusReader = { it.wheel.lightOn }
+        ),
+        ActionSpec(
+            key = "LOCK_TOGGLE",
+            labelRes = R.string.action_chip_lock,
+            icon = Icons.Filled.Lock,
+            isEyesFreeSafe = true,
+            // pcMode == 0 means locked. -1 (unknown) returns false so the
+            // tile doesn't render an "active" state before the wheel has
+            // sent a mode frame.
+            statusReader = { it.wheel.pcMode == 0 }
+        ),
+        ActionSpec(
+            key = "SAFETY_TOGGLE",
+            labelRes = R.string.action_chip_safety,
+            icon = Icons.Filled.Shield,
+            isEyesFreeSafe = true,
+            statusReader = { it.safetyActive }
+        ),
+        ActionSpec(
+            key = "SAFETY_ON",
+            labelRes = R.string.action_chip_safety_on,
+            icon = Icons.Filled.Shield,
+            isEyesFreeSafe = true,
+            // Highlight when ALREADY in safety mode — pressing this is a
+            // no-op in that case, so the active state warns the rider.
+            statusReader = { it.safetyActive }
+        ),
+        ActionSpec(
+            key = "SAFETY_OFF",
+            labelRes = R.string.action_chip_safety_off,
+            icon = Icons.Filled.Shield,
+            isEyesFreeSafe = true,
+            // Mirror of SAFETY_ON — highlight when already off.
+            statusReader = { !it.safetyActive }
+        ),
+        ActionSpec(
+            key = "VOICE_ANNOUNCE",
+            labelRes = R.string.action_chip_voice,
+            icon = Icons.Filled.RecordVoiceOver,
+            isEyesFreeSafe = true
+        ),
+        ActionSpec(
+            key = "RECORD_TOGGLE",
+            labelRes = R.string.action_chip_record,
+            icon = Icons.Filled.FiberManualRecord,
+            isEyesFreeSafe = true,
+            statusReader = { it.tripRecording }
+        ),
+        ActionSpec(
+            key = "RECORD_START",
+            labelRes = R.string.action_chip_record_start,
+            icon = Icons.Filled.FiberManualRecord,
+            isEyesFreeSafe = true,
+            // Already-recording = pressing this is a no-op; highlight to
+            // signal "no change will happen if you tap this".
+            statusReader = { it.tripRecording }
+        ),
+        ActionSpec(
+            key = "RECORD_STOP",
+            labelRes = R.string.action_chip_record_stop,
+            icon = Icons.Filled.FiberManualRecord,
+            isEyesFreeSafe = true,
+            statusReader = { !it.tripRecording }
+        ),
+        ActionSpec(
+            key = "MEDIA_PLAY_PAUSE",
+            labelRes = R.string.action_chip_media_play,
+            icon = Icons.Filled.PlayArrow,
+            isEyesFreeSafe = true
+        ),
+        ActionSpec(
+            key = "MEDIA_NEXT",
+            labelRes = R.string.action_chip_media_next,
+            icon = Icons.Filled.SkipNext,
+            isEyesFreeSafe = true
+        ),
+        ActionSpec(
+            key = "MEDIA_PREVIOUS",
+            labelRes = R.string.action_chip_media_prev,
+            icon = Icons.Filled.SkipPrevious,
+            isEyesFreeSafe = true
+        ),
+
+        // ---- Dashboard-only (need screen attention or are destructive) ----
+        ActionSpec(
+            key = "OPEN_NAVIGATION",
+            labelRes = R.string.action_chip_open_navigation,
+            icon = Icons.Filled.Navigation
+        ),
+        ActionSpec(
+            key = "OPEN_STUDIO",
+            labelRes = R.string.action_chip_open_studio,
+            icon = Icons.Filled.PhotoCamera
+        ),
+        ActionSpec(
+            key = "OPEN_ABOUT",
+            labelRes = R.string.action_chip_open_about,
+            icon = Icons.Filled.Info
+        ),
+        ActionSpec(
+            key = "OPEN_SERVICE",
+            labelRes = R.string.action_chip_open_service,
+            icon = Icons.Filled.Build
+        ),
+        ActionSpec(
+            key = "OPEN_TRIPS",
+            labelRes = R.string.action_chip_open_trips,
+            icon = Icons.AutoMirrored.Filled.List
+        ),
+        ActionSpec(
+            key = "MUTE_ALARMS",
+            labelRes = R.string.action_chip_mute_alarms,
+            icon = Icons.AutoMirrored.Filled.VolumeOff,
+            statusReader = { it.alarmsMuted }
+        ),
+        ActionSpec(
+            key = "RESET_TRIP",
+            labelRes = R.string.action_chip_reset_trip,
+            icon = Icons.Filled.Restore
+        ),
+        ActionSpec(
+            key = "TOGGLE_UNITS",
+            labelRes = R.string.action_chip_toggle_units,
+            icon = Icons.Filled.SwapHoriz,
+            statusReader = { it.imperialUnits }
+        )
+    )
+
+    private val byKeyMap: Map<String, ActionSpec> = all.associateBy { it.key }
+
+    fun byKey(key: String): ActionSpec? = byKeyMap[key]
+
+    /**
+     * The list of action keys eligible for [surface], in catalog declaration
+     * order. Callers that need alphabetical ordering (like the dashboard
+     * pool) sort by display label themselves.
+     */
+    fun keysFor(surface: ActionSurface): List<String> = when (surface) {
+        // Riders looking at the screen can pick anything.
+        ActionSurface.DASHBOARD, ActionSurface.VOICE -> all.map { it.key }
+        // Physical / hands-free / automated surfaces only see eyes-free actions.
+        ActionSurface.FLIC,
+        ActionSurface.VOLUME_KEY,
+        ActionSurface.WATCH,
+        ActionSurface.TRIGGER,
+        ActionSurface.ALARM_FIRE -> all.filter { it.isEyesFreeSafe }.map { it.key }
+    }
+
+    /**
+     * The set of surfaces an action can be bound to. Derived from
+     * [ActionSpec.isEyesFreeSafe]: eyes-free actions land on every
+     * surface, screen-required actions only land on DASHBOARD + VOICE.
+     */
+    fun surfacesFor(spec: ActionSpec): Set<ActionSurface> = if (spec.isEyesFreeSafe) {
+        ActionSurface.values().toSet()
+    } else {
+        setOf(ActionSurface.DASHBOARD, ActionSurface.VOICE)
+    }
+}

--- a/app/src/main/java/com/eried/eucplanet/data/model/AppSettings.kt
+++ b/app/src/main/java/com/eried/eucplanet/data/model/AppSettings.kt
@@ -391,22 +391,68 @@ data class AppSettings(
      * element to 100% opacity so half-transparent elements don't blend with
      * the chroma fill and look wrong. Default on.
      */
-    val studioReplayForceOpaque: Boolean = true
+    val studioReplayForceOpaque: Boolean = true,
+
+    // Dashboard layout (customizable home screen).
+    //
+    // Metric / action order is a comma-separated list of enum-name keys; unknown
+    // tokens are dropped and known-but-missing tokens are appended in canonical
+    // order when read, so adding a new metric or action later just expands the
+    // default list without breaking existing rider settings.
+    val dashboardMetricsColumns: Int = 2,
+    val dashboardActionsColumns: Int = 3,
+    val dashboardMetricOrder: String = "BATTERY,TEMPERATURE,VOLTAGE,CURRENT,LOAD,TRIP",
+    val dashboardActionOrder: String = "HORN,LIGHT_TOGGLE,VOICE_ANNOUNCE,SAFETY_TOGGLE,LOCK_TOGGLE,RECORD_TOGGLE",
+    val dashboardRollingWindowSeconds: Int = 300,
+
+    /**
+     * Composite metric definitions as a JSON object keyed by synthetic ID
+     * (`M:<uuid>`). Each value is `{ "layout": "ROW2"|"COL2"|"COL3", "cells":
+     * [<metric_key>, ...] }`. Composite IDs appear in [dashboardMetricOrder]
+     * alongside regular metric keys — a single grid slot renders the composite
+     * as a multi-cell tile instead of one metric. Empty object `"{}"` means
+     * the rider hasn't dragged the `+ Stack` template onto the grid yet.
+     */
+    val dashboardCompositeMetrics: String = "{}",
+
+    /**
+     * Action group definitions as a JSON object keyed by `G:<uuid>`. Each
+     * value is `{ "actions": [<action_key>, ...] }` with up to 4 entries.
+     * Group IDs appear in [dashboardActionOrder]; a single action slot
+     * renders the group as one button whose tap opens an anchored popover
+     * with the sub-actions.
+     */
+    val dashboardActionGroups: String = "{}",
+
+    /**
+     * Custom tile definitions as a JSON object keyed by `C:<uuid>`. Each value
+     * is `{ "text": <label>, "icon": <icon_key>, "action": <type>, "url": <url> }`.
+     * Action types: NONE (display-only label), OPEN_URL (tap opens default
+     * browser), SHOW_QR (tap shows a QR-code popup so other riders can scan
+     * and visit the URL — e.g. Instagram handle, club page). Custom tile IDs
+     * appear in [dashboardMetricOrder] alongside regular metrics.
+     */
+    val dashboardCustomTiles: String = "{}",
+
+    /**
+     * Per-metric corner-stat configuration as a JSON object. Each known metric
+     * key maps to a config object with five stat slots (center, top-left,
+     * top-right, bottom-left, bottom-right) and a sparkline flag. Defaults are
+     * applied at read time when an entry is missing — empty object means every
+     * metric uses center=CURRENT, others=NONE, sparkline=true. Persisted as a
+     * single string so we don't need to grow AppSettings each time a new stat
+     * lands.
+     *
+     * Schema:
+     * `{"BATTERY":{"c":"CURRENT","tl":"MIN","tr":"MAX","bl":"NONE","br":"AVG","spark":true}}`
+     *
+     * Stat values: NONE | CURRENT | MIN | MAX | AVG.
+     */
+    val dashboardMetricStats: String = "{}"
 )
 
-enum class FlicAction(val labelRes: Int) {
-    NONE(R.string.flic_action_none),
-    HORN(R.string.flic_action_horn),
-    LIGHT_TOGGLE(R.string.flic_action_light),
-    LOCK_TOGGLE(R.string.flic_action_lock),
-    SAFETY_TOGGLE(R.string.flic_action_legal_toggle),
-    SAFETY_ON(R.string.flic_action_legal_on),
-    SAFETY_OFF(R.string.flic_action_legal_off),
-    VOICE_ANNOUNCE(R.string.flic_action_voice),
-    RECORD_TOGGLE(R.string.flic_action_record),
-    RECORD_START(R.string.flic_action_record_start),
-    RECORD_STOP(R.string.flic_action_record_stop),
-    MEDIA_PLAY_PAUSE(R.string.flic_action_media_play),
-    MEDIA_NEXT(R.string.flic_action_media_next),
-    MEDIA_PREVIOUS(R.string.flic_action_media_prev)
-}
+// FlicAction enum removed (2026-05). Replaced by
+// [com.eried.eucplanet.data.model.ActionCatalog] which is the single source
+// of truth for every rider-triggerable command and the surfaces it can be
+// bound to. Settings still store the action name as a String (e.g. "HORN",
+// "VOICE_ANNOUNCE", or "NONE" for unbound) so there is no schema change.

--- a/app/src/main/java/com/eried/eucplanet/data/model/MetricCatalog.kt
+++ b/app/src/main/java/com/eried/eucplanet/data/model/MetricCatalog.kt
@@ -1,0 +1,398 @@
+package com.eried.eucplanet.data.model
+
+import androidx.annotation.StringRes
+import androidx.compose.ui.graphics.Color
+import com.eried.eucplanet.R
+import com.eried.eucplanet.ui.theme.AccentBlue
+import com.eried.eucplanet.ui.theme.AccentGreen
+import com.eried.eucplanet.ui.theme.AccentOrange
+import com.eried.eucplanet.ui.theme.AccentPink
+import com.eried.eucplanet.ui.theme.AccentPurple
+
+/**
+ * Metric layer — single source of truth for every metric the dashboard
+ * editor catalogues, the live dashboard renders, and the debug overlay
+ * reflects on. Mirrors [ActionCatalog]: adding a new metric is one entry
+ * in [MetricCatalog.all]; the editor / live dashboard / debug overlay
+ * all pick it up automatically.
+ *
+ * The catalog deliberately stores UI-affecting metadata (accent color,
+ * sparkline style, supports-stats flag) but NOT raw value extraction or
+ * unit conversion. Those stay in the live dashboard because they need
+ * AppSettings (for imperial/metric) and WheelData (for the wheel
+ * snapshot) — keeping the catalog free of those references means it
+ * stays a pure metadata declaration that compiles with no dependencies
+ * beyond Compose colour primitives.
+ *
+ * The PER-METRIC sparkline style is what gives each tile its identity
+ * on the live dashboard: CURRENT renders as a bipolar area (regen vs
+ * draw on either side of zero), counter-style metrics like TRIP /
+ * ODOMETER skip the sparkline entirely, the rest pick a line, smoothed
+ * line, or filled area as appropriate.
+ */
+
+/**
+ * How the rolling sparkline behind a metric tile should be drawn. The
+ * live dashboard reads this when [MetricSlotStats.sparkline] is enabled.
+ * Choosing a style is purely visual — corner stats (min/max/avg) compute
+ * from the same history regardless of the style picked, and remain
+ * computable even when the rider hides the sparkline.
+ */
+enum class SparklineStyle {
+    /** No background sparkline. Used for monotonic counters where a chart isn't meaningful. */
+    NONE,
+
+    /** Thin stroke connecting samples. */
+    LINE,
+
+    /** Stroke with a Catmull-Rom-ish smoothing pass — softer for slow-moving metrics. */
+    SMOOTH_LINE,
+
+    /** Stroke + faint fill underneath; the dashboard's default treatment historically. */
+    AREA,
+
+    /**
+     * Stroke + fill above OR below a baseline (usually 0). Used for
+     * bipolar metrics like CURRENT (regen vs draw), TORQUE (drive vs
+     * brake), PITCH/ROLL angles. Renderer fills the positive lobe in
+     * the accent colour and the negative lobe in a secondary tint.
+     */
+    AREA_BIPOLAR
+}
+
+/**
+ * Metadata for a single dashboard metric. Catalog declares one of these
+ * per static metric key. Dynamic instances (`M:uuid` composites, `C:uuid`
+ * custom tiles) don't have entries here — they pull cells from the
+ * catalog at render time but have their own per-instance state.
+ */
+data class MetricSpec(
+    /** Stable identifier persisted in settings (composites/custom tiles reference these by key too). */
+    val key: String,
+    @StringRes val labelRes: Int,
+    /** Optional explainer surfaced in the slot-sheet info box. */
+    @StringRes val descriptionRes: Int? = null,
+    /** Accent colour the tile's value text + sparkline tint pick up. */
+    val accent: Color = AccentBlue,
+    /** Sparkline drawing style. [SparklineStyle.NONE] for monotonic counters. */
+    val sparkline: SparklineStyle = SparklineStyle.AREA,
+    /**
+     * True when min / max / avg / percentiles compute meaningfully for
+     * this metric. False for monotonic counters (TRIP, ODOMETER, trip-
+     * time, energy totals) and circular values (GPS_HEADING wraps at
+     * 360°).
+     */
+    val supportsStats: Boolean = true,
+    /**
+     * Baseline for [SparklineStyle.AREA_BIPOLAR]. Usually 0 — separates
+     * the positive lobe (drawn in [accent]) from the negative lobe
+     * (drawn in [bipolarNegativeAccent], or a darker tint of [accent]
+     * if null).
+     */
+    val bipolarBaseline: Float = 0f,
+    /** Colour for the negative lobe when [sparkline] is [SparklineStyle.AREA_BIPOLAR]. */
+    val bipolarNegativeAccent: Color? = null
+)
+
+object MetricCatalog {
+
+    val all: List<MetricSpec> = listOf(
+        // ---- Default active grid (first 6 on a fresh install) ----
+        MetricSpec(
+            key = "BATTERY",
+            labelRes = R.string.metric_chip_battery,
+            accent = AccentGreen,
+            sparkline = SparklineStyle.AREA
+        ),
+        MetricSpec(
+            key = "TEMPERATURE",
+            labelRes = R.string.metric_chip_temperature,
+            accent = AccentOrange,
+            sparkline = SparklineStyle.AREA
+        ),
+        MetricSpec(
+            key = "VOLTAGE",
+            labelRes = R.string.metric_chip_voltage,
+            accent = AccentBlue,
+            sparkline = SparklineStyle.LINE
+        ),
+        MetricSpec(
+            key = "CURRENT",
+            labelRes = R.string.metric_chip_current,
+            accent = AccentBlue,
+            sparkline = SparklineStyle.AREA_BIPOLAR,
+            bipolarNegativeAccent = AccentGreen   // regen reads as positive feedback
+        ),
+        MetricSpec(
+            key = "LOAD",
+            labelRes = R.string.metric_chip_load,
+            accent = AccentOrange,
+            sparkline = SparklineStyle.AREA
+        ),
+        MetricSpec(
+            key = "TRIP",
+            labelRes = R.string.metric_chip_trip,
+            accent = AccentGreen,
+            sparkline = SparklineStyle.NONE,       // monotonic counter
+            supportsStats = false
+        ),
+
+        // ---- Pool (already-buffered) ----
+        MetricSpec(
+            key = "SPEED",
+            labelRes = R.string.metric_chip_speed,
+            accent = AccentGreen,
+            sparkline = SparklineStyle.SMOOTH_LINE
+        ),
+        MetricSpec(
+            key = "POWER",
+            labelRes = R.string.metric_chip_power,
+            accent = AccentOrange,
+            sparkline = SparklineStyle.AREA_BIPOLAR,
+            bipolarNegativeAccent = AccentGreen
+        ),
+        MetricSpec(
+            key = "ODOMETER",
+            labelRes = R.string.metric_chip_odometer,
+            accent = AccentGreen,
+            sparkline = SparklineStyle.NONE,
+            supportsStats = false
+        ),
+        MetricSpec(
+            key = "MOTOR_POWER",
+            labelRes = R.string.metric_chip_motor_power,
+            accent = AccentOrange,
+            sparkline = SparklineStyle.AREA_BIPOLAR,
+            bipolarNegativeAccent = AccentGreen
+        ),
+        MetricSpec(
+            key = "BATTERY_POWER",
+            labelRes = R.string.metric_chip_battery_power,
+            accent = AccentOrange,
+            sparkline = SparklineStyle.AREA_BIPOLAR,
+            bipolarNegativeAccent = AccentGreen
+        ),
+        MetricSpec(
+            key = "BATTERY_1",
+            labelRes = R.string.metric_chip_battery_1,
+            accent = AccentGreen,
+            sparkline = SparklineStyle.AREA
+        ),
+        MetricSpec(
+            key = "BATTERY_2",
+            labelRes = R.string.metric_chip_battery_2,
+            accent = AccentGreen,
+            sparkline = SparklineStyle.AREA
+        ),
+        MetricSpec(
+            key = "PITCH",
+            labelRes = R.string.metric_chip_pitch,
+            accent = AccentPurple,
+            sparkline = SparklineStyle.AREA_BIPOLAR
+        ),
+        MetricSpec(
+            key = "ROLL",
+            labelRes = R.string.metric_chip_roll,
+            accent = AccentPurple,
+            sparkline = SparklineStyle.AREA_BIPOLAR
+        ),
+        MetricSpec(
+            key = "G_FORCE",
+            labelRes = R.string.metric_chip_g_force,
+            accent = AccentPink,
+            sparkline = SparklineStyle.AREA
+        ),
+        MetricSpec(
+            key = "LATERAL_G",
+            labelRes = R.string.metric_chip_lateral_g,
+            accent = AccentPink,
+            sparkline = SparklineStyle.AREA_BIPOLAR
+        ),
+        MetricSpec(
+            key = "FORWARD_G",
+            labelRes = R.string.metric_chip_forward_g,
+            accent = AccentPink,
+            sparkline = SparklineStyle.AREA_BIPOLAR
+        ),
+        MetricSpec(
+            key = "TORQUE",
+            labelRes = R.string.metric_chip_torque,
+            accent = AccentBlue,
+            sparkline = SparklineStyle.AREA_BIPOLAR,
+            bipolarNegativeAccent = AccentGreen
+        ),
+        MetricSpec(
+            key = "DYN_SPEED_LIMIT",
+            labelRes = R.string.metric_chip_dyn_speed_limit,
+            accent = AccentBlue,
+            sparkline = SparklineStyle.LINE
+        ),
+        MetricSpec(
+            key = "DYN_CURRENT_LIMIT",
+            labelRes = R.string.metric_chip_dyn_current_limit,
+            accent = AccentBlue,
+            sparkline = SparklineStyle.LINE
+        ),
+
+        // ---- Individual temperature sensors ----
+        MetricSpec(
+            key = "MOTOR_TEMP",
+            labelRes = R.string.metric_chip_motor_temp,
+            accent = AccentOrange,
+            sparkline = SparklineStyle.AREA
+        ),
+        MetricSpec(
+            key = "CONTROLLER_TEMP",
+            labelRes = R.string.metric_chip_controller_temp,
+            accent = AccentOrange,
+            sparkline = SparklineStyle.AREA
+        ),
+        MetricSpec(
+            key = "BATTERY_TEMP",
+            labelRes = R.string.metric_chip_battery_temp,
+            accent = AccentOrange,
+            sparkline = SparklineStyle.AREA
+        ),
+
+        // ---- Derived trip aggregates ----
+        MetricSpec(
+            key = "HEADROOM",
+            labelRes = R.string.metric_chip_headroom,
+            descriptionRes = R.string.metric_desc_headroom,
+            accent = AccentBlue,
+            sparkline = SparklineStyle.LINE
+        ),
+        MetricSpec(
+            key = "TRIP_TIME",
+            labelRes = R.string.metric_chip_trip_time,
+            accent = AccentBlue,
+            sparkline = SparklineStyle.NONE,
+            supportsStats = false
+        ),
+        MetricSpec(
+            key = "TRIP_MAX_SPEED",
+            labelRes = R.string.metric_chip_trip_max_speed,
+            descriptionRes = R.string.metric_desc_trip_max_speed,
+            accent = AccentGreen,
+            sparkline = SparklineStyle.NONE,
+            supportsStats = false
+        ),
+        MetricSpec(
+            key = "AVG_TRIP_SPEED",
+            labelRes = R.string.metric_chip_avg_trip_speed,
+            descriptionRes = R.string.metric_desc_avg_trip_speed,
+            accent = AccentGreen,
+            sparkline = SparklineStyle.NONE,
+            supportsStats = false
+        ),
+        MetricSpec(
+            key = "WH_CONSUMED",
+            labelRes = R.string.metric_chip_wh_consumed,
+            descriptionRes = R.string.metric_desc_wh_consumed,
+            accent = AccentOrange,
+            sparkline = SparklineStyle.NONE,
+            supportsStats = false
+        ),
+        MetricSpec(
+            key = "RANGE_ESTIMATE",
+            labelRes = R.string.metric_chip_range_estimate,
+            descriptionRes = R.string.metric_desc_range_estimate,
+            accent = AccentGreen,
+            sparkline = SparklineStyle.LINE
+        ),
+        MetricSpec(
+            key = "WH_PER_KM",
+            labelRes = R.string.metric_chip_wh_per_km,
+            descriptionRes = R.string.metric_desc_wh_per_km,
+            accent = AccentOrange,
+            sparkline = SparklineStyle.LINE
+        ),
+
+        // ---- Phone + GPS feeds ----
+        MetricSpec(
+            key = "PHONE_BATTERY",
+            labelRes = R.string.metric_chip_phone_battery,
+            accent = AccentGreen,
+            sparkline = SparklineStyle.AREA
+        ),
+        MetricSpec(
+            key = "GPS_ALTITUDE",
+            labelRes = R.string.metric_chip_gps_altitude,
+            accent = AccentPurple,
+            sparkline = SparklineStyle.SMOOTH_LINE
+        ),
+        MetricSpec(
+            key = "GPS_SPEED",
+            labelRes = R.string.metric_chip_gps_speed,
+            accent = AccentGreen,
+            sparkline = SparklineStyle.SMOOTH_LINE
+        ),
+        MetricSpec(
+            key = "GPS_HEADING",
+            labelRes = R.string.metric_chip_gps_heading,
+            accent = AccentPurple,
+            // GPS_HEADING wraps at 360°; sparkline + stats are misleading for circular values.
+            sparkline = SparklineStyle.NONE,
+            supportsStats = false
+        ),
+        MetricSpec(
+            key = "GPS_ACCURACY",
+            labelRes = R.string.metric_chip_gps_accuracy,
+            descriptionRes = R.string.metric_desc_gps_accuracy,
+            accent = AccentPurple,
+            sparkline = SparklineStyle.LINE
+        ),
+
+        // ---- Derived motion + pack health ----
+        MetricSpec(
+            key = "SLOPE",
+            labelRes = R.string.metric_chip_slope,
+            descriptionRes = R.string.metric_desc_slope,
+            accent = AccentPurple,
+            sparkline = SparklineStyle.AREA_BIPOLAR
+        ),
+        MetricSpec(
+            key = "ASCENT",
+            labelRes = R.string.metric_chip_ascent,
+            accent = AccentPurple,
+            sparkline = SparklineStyle.NONE,
+            supportsStats = false
+        ),
+        MetricSpec(
+            key = "DESCENT",
+            labelRes = R.string.metric_chip_descent,
+            accent = AccentPurple,
+            sparkline = SparklineStyle.NONE,
+            supportsStats = false
+        ),
+        MetricSpec(
+            key = "MOTOR_RPM",
+            labelRes = R.string.metric_chip_motor_rpm,
+            accent = AccentOrange,
+            sparkline = SparklineStyle.LINE
+        ),
+        MetricSpec(
+            key = "REGEN_WH",
+            labelRes = R.string.metric_chip_regen_wh,
+            descriptionRes = R.string.metric_desc_regen_wh,
+            accent = AccentGreen,
+            sparkline = SparklineStyle.NONE,
+            supportsStats = false
+        ),
+
+        // ---- Connectivity diagnostic ----
+        MetricSpec(
+            key = "BT_RSSI",
+            labelRes = R.string.metric_chip_bt_rssi,
+            descriptionRes = R.string.metric_desc_bt_rssi,
+            accent = AccentBlue,
+            sparkline = SparklineStyle.LINE
+        )
+    )
+
+    private val byKeyMap: Map<String, MetricSpec> = all.associateBy { it.key }
+
+    fun byKey(key: String): MetricSpec? = byKeyMap[key]
+
+    val keys: List<String> = all.map { it.key }
+}

--- a/app/src/main/java/com/eried/eucplanet/data/repository/WheelRepository.kt
+++ b/app/src/main/java/com/eried/eucplanet/data/repository/WheelRepository.kt
@@ -142,6 +142,31 @@ class WheelRepository @Inject constructor(
     private val _fullHistory = MutableStateFlow(FullMetricHistory())
     val fullHistory: StateFlow<FullMetricHistory> = _fullHistory.asStateFlow()
 
+    /**
+     * Clears the in-memory rolling history buffer for one metric key.
+     * Used by the metric-detail Reset button so the rider can re-seed
+     * a clean chart (e.g. after a recovery from a noisy connection).
+     * Settings and trip records are untouched — fresh samples re-seed
+     * the buffer at the next 1Hz tick.
+     */
+    fun resetHistory(key: String) {
+        val current = _fullHistory.value
+        _fullHistory.value = when (key) {
+            "BATTERY" -> current.copy(battery = emptyList())
+            "TEMPERATURE" -> current.copy(temperature = emptyList())
+            "VOLTAGE" -> current.copy(voltage = emptyList())
+            "CURRENT" -> current.copy(current = emptyList())
+            "LOAD" -> current.copy(load = emptyList())
+            "SPEED" -> current.copy(speed = emptyList())
+            else -> current
+        }
+    }
+
+    /** Clears every in-memory rolling history buffer. */
+    fun resetAllHistory() {
+        _fullHistory.value = FullMetricHistory()
+    }
+
     // Auth state for lock/unlock (V14 requires password verification)
     private var authKey: ByteArray? = null
     private var pendingAuthKeyDeferred: CompletableDeferred<ByteArray>? = null

--- a/app/src/main/java/com/eried/eucplanet/data/store/SettingsJson.kt
+++ b/app/src/main/java/com/eried/eucplanet/data/store/SettingsJson.kt
@@ -192,6 +192,15 @@ object SettingsJson {
         put("studioReplayVideoFormat", s.studioReplayVideoFormat)
         put("studioReplayChromaColor", s.studioReplayChromaColor)
         put("studioReplayForceOpaque", s.studioReplayForceOpaque)
+        put("dashboardMetricsColumns", s.dashboardMetricsColumns)
+        put("dashboardActionsColumns", s.dashboardActionsColumns)
+        put("dashboardMetricOrder", s.dashboardMetricOrder)
+        put("dashboardActionOrder", s.dashboardActionOrder)
+        put("dashboardRollingWindowSeconds", s.dashboardRollingWindowSeconds)
+        put("dashboardMetricStats", s.dashboardMetricStats)
+        put("dashboardCompositeMetrics", s.dashboardCompositeMetrics)
+        put("dashboardActionGroups", s.dashboardActionGroups)
+        put("dashboardCustomTiles", s.dashboardCustomTiles)
     }
 
     fun fromJson(j: JSONObject, base: AppSettings = AppSettings()): AppSettings = base.copy(
@@ -357,7 +366,21 @@ object SettingsJson {
         studioReplayPhotoFormat = j.optString("studioReplayPhotoFormat", base.studioReplayPhotoFormat),
         studioReplayVideoFormat = j.optString("studioReplayVideoFormat", base.studioReplayVideoFormat),
         studioReplayChromaColor = j.optLong("studioReplayChromaColor", base.studioReplayChromaColor),
-        studioReplayForceOpaque = j.optBoolean("studioReplayForceOpaque", base.studioReplayForceOpaque)
+        studioReplayForceOpaque = j.optBoolean("studioReplayForceOpaque", base.studioReplayForceOpaque),
+        dashboardMetricsColumns = j.optInt("dashboardMetricsColumns", base.dashboardMetricsColumns),
+        dashboardActionsColumns = j.optInt("dashboardActionsColumns", base.dashboardActionsColumns),
+        dashboardMetricOrder = j.optString("dashboardMetricOrder", base.dashboardMetricOrder),
+        dashboardActionOrder = j.optString("dashboardActionOrder", base.dashboardActionOrder),
+        dashboardRollingWindowSeconds = j.optInt(
+            "dashboardRollingWindowSeconds",
+            // Migrate older builds that stored the window in minutes.
+            j.optInt("dashboardRollingWindowMinutes", -1)
+                .let { if (it > 0) it * 60 else base.dashboardRollingWindowSeconds }
+        ),
+        dashboardMetricStats = j.optString("dashboardMetricStats", base.dashboardMetricStats),
+        dashboardCompositeMetrics = j.optString("dashboardCompositeMetrics", base.dashboardCompositeMetrics),
+        dashboardActionGroups = j.optString("dashboardActionGroups", base.dashboardActionGroups),
+        dashboardCustomTiles = j.optString("dashboardCustomTiles", base.dashboardCustomTiles)
     )
 
     /** `optString` returns `""` for null and absent keys, which we cannot

--- a/app/src/main/java/com/eried/eucplanet/diagnostics/ServiceOverlay.kt
+++ b/app/src/main/java/com/eried/eucplanet/diagnostics/ServiceOverlay.kt
@@ -1,0 +1,421 @@
+package com.eried.eucplanet.diagnostics
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.res.stringResource
+import com.eried.eucplanet.data.model.ActionCatalog
+import com.eried.eucplanet.data.model.ActionSpec
+import com.eried.eucplanet.data.model.ActionSurface
+import com.eried.eucplanet.data.model.WheelData
+import com.eried.eucplanet.data.repository.FullMetricHistory
+import com.eried.eucplanet.data.repository.MetricSample
+import com.eried.eucplanet.ui.settings.metricAccentColor
+import com.eried.eucplanet.ui.settings.metricChipLabel
+import com.eried.eucplanet.ui.settings.metricDescription
+import com.eried.eucplanet.ui.settings.metricSupportsStats
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Snapshot fed to [ServiceModeOverlay]. Captured once when the overlay
+ * opens so the values stay frozen while the rider inspects them. The
+ * activity re-snapshots after every fire so action-status readouts
+ * reflect the new state.
+ */
+data class ServiceOverlaySnapshot(
+    val wheel: WheelData,
+    val history: FullMetricHistory,
+    /** True while [com.eried.eucplanet.data.repository.TripRepository.recording] is on. */
+    val tripRecording: Boolean,
+    /** Imperial-unit toggle state, used as the status for TOGGLE_UNITS. */
+    val imperialUnits: Boolean,
+    /** True when the wheel is currently in safety / legal mode. */
+    val safetyActive: Boolean = false,
+    /** True when the alarms-muted setting is on. */
+    val alarmsMuted: Boolean = false
+) {
+    /** Projects into the catalog's read-only StatusContext for [com.eried.eucplanet.data.model.ActionSpec.statusReader]. */
+    fun toStatusContext(): com.eried.eucplanet.data.model.StatusContext =
+        com.eried.eucplanet.data.model.StatusContext(
+            wheel = wheel,
+            tripRecording = tripRecording,
+            imperialUnits = imperialUnits,
+            alarmsMuted = alarmsMuted,
+            safetyActive = safetyActive
+        )
+}
+
+/**
+ * Global open/close state + the snapshot to render. Lives as a singleton
+ * because the volume-key trigger fires from
+ * [com.eried.eucplanet.MainActivity.onKeyDown] (outside the Compose tree)
+ * and the overlay is rendered from `setContent`.
+ */
+object ServiceOverlayState {
+    private val _open = MutableStateFlow(false)
+    val open: StateFlow<Boolean> = _open.asStateFlow()
+
+    private val _snapshot = MutableStateFlow<ServiceOverlaySnapshot?>(null)
+    val snapshot: StateFlow<ServiceOverlaySnapshot?> = _snapshot.asStateFlow()
+
+    fun show(snapshot: ServiceOverlaySnapshot) {
+        _snapshot.value = snapshot
+        _open.value = true
+    }
+
+    /** Replace the snapshot without changing open state. Used after the rider fires an action. */
+    fun refresh(snapshot: ServiceOverlaySnapshot) {
+        _snapshot.value = snapshot
+    }
+
+    fun dismiss() {
+        _open.value = false
+    }
+}
+
+/**
+ * Compact debug overlay. Two combos with detail panes below each:
+ *   - Metric combo → raw / count / min / max / avg / last samples
+ *   - Action combo + Fire button → current status (where known)
+ *
+ * Designed as a developer surface. No realtime updates; the snapshot
+ * refreshes after every fire so status readouts catch up.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ServiceModeOverlay(
+    snapshot: ServiceOverlaySnapshot,
+    onFireAction: (key: String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(
+                    "Debug",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f)
+                )
+                IconButton(onClick = onDismiss) {
+                    Icon(Icons.Filled.Close, contentDescription = "Close")
+                }
+            }
+            Spacer(Modifier.height(8.dp))
+
+            MetricPicker(snapshot = snapshot)
+
+            Spacer(Modifier.height(16.dp))
+
+            ActionPicker(snapshot = snapshot, onFire = onFireAction)
+
+            Spacer(Modifier.height(16.dp))
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun MetricPicker(snapshot: ServiceOverlaySnapshot) {
+    var expanded by remember { mutableStateOf(false) }
+    var selected by remember { mutableStateOf(serviceMetricKeys.first()) }
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = !expanded }
+    ) {
+        OutlinedTextField(
+            value = selected,
+            onValueChange = {},
+            readOnly = true,
+            singleLine = true,
+            label = { Text("Metric") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable, enabled = true)
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            serviceMetricKeys.forEach { key ->
+                DropdownMenuItem(
+                    text = { Text(key, fontFamily = FontFamily.Monospace) },
+                    onClick = {
+                        selected = key
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+    Spacer(Modifier.height(8.dp))
+    DetailBox(text = composeMetricDetailText(selected, snapshot))
+}
+
+/** @Composable wrapper so we can read stringResource()-backed metric metadata. */
+@Composable
+private fun composeMetricDetailText(key: String, snapshot: ServiceOverlaySnapshot): String {
+    val label = metricChipLabel(key)
+    val description = metricDescription(key)
+    val accent = metricAccentColor(key)
+    val accentName = accentLabelFor(accent)
+    val supportsStats = metricSupportsStats(key)
+    val raw = rawMetricValue(key, snapshot.wheel)
+    val history = historyFor(key, snapshot.history)
+    val hasHistory = !history.isNullOrEmpty()
+
+    return buildString {
+        append("key:    ").append(key).append('\n')
+        append("label:  ").append(label).append('\n')
+        if (description != null) {
+            append("desc:   ").append(description).append('\n')
+        }
+        append("accent: ").append(accentName).append('\n')
+        append("stats:  ").append(if (supportsStats) "supported" else "not applicable")
+        append('\n')
+        append("hist:   ").append(if (hasHistory) "buffer (1Hz, 5min window)" else "none")
+        append('\n')
+        append("raw:    ").append(raw)
+        if (hasHistory) {
+            val values = history!!.map { it.value }
+            append('\n').append("count:  ").append(values.size)
+            append('\n').append("min:    ").append("%.4f".format(values.min()))
+            append('\n').append("max:    ").append("%.4f".format(values.max()))
+            append('\n').append("avg:    ").append("%.4f".format(values.average()))
+            append('\n').append("last:   ").append(values.takeLast(8).joinToString(", ") { "%.2f".format(it) })
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ActionPicker(
+    snapshot: ServiceOverlaySnapshot,
+    onFire: (String) -> Unit
+) {
+    val keys = remember { ActionCatalog.keysFor(ActionSurface.DASHBOARD) }
+    var expanded by remember { mutableStateOf(false) }
+    var selected by remember { mutableStateOf(keys.first()) }
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        ExposedDropdownMenuBox(
+            expanded = expanded,
+            onExpandedChange = { expanded = !expanded },
+            modifier = Modifier.weight(1f)
+        ) {
+            OutlinedTextField(
+                value = selected,
+                onValueChange = {},
+                readOnly = true,
+                singleLine = true,
+                label = { Text("Action") },
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .menuAnchor(MenuAnchorType.PrimaryNotEditable, enabled = true)
+            )
+            ExposedDropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false }
+            ) {
+                keys.forEach { key ->
+                    DropdownMenuItem(
+                        text = { Text(key, fontFamily = FontFamily.Monospace) },
+                        onClick = {
+                            selected = key
+                            expanded = false
+                        }
+                    )
+                }
+            }
+        }
+        FilledTonalButton(onClick = { onFire(selected) }) {
+            Icon(Icons.Filled.PlayArrow, contentDescription = null, modifier = Modifier.padding(end = 4.dp))
+            Text("Fire")
+        }
+    }
+    Spacer(Modifier.height(8.dp))
+    DetailBox(text = composeActionDetailText(selected, snapshot))
+}
+
+/** @Composable wrapper so we can read stringResource()-backed action labels. */
+@Composable
+private fun composeActionDetailText(key: String, snapshot: ServiceOverlaySnapshot): String {
+    val spec: ActionSpec? = ActionCatalog.byKey(key)
+    if (spec == null) {
+        return "key: $key\n(not in ActionCatalog)"
+    }
+    val label = stringResource(spec.labelRes)
+    val surfaces = ActionCatalog.surfacesFor(spec).joinToString(", ") { it.name }
+    val iconName = spec.icon?.name ?: "(none)"
+    val hasStatusReader = spec.statusReader != null
+    val statusLine = actionStatusText(key, snapshot)
+    return buildString {
+        append("key:        ").append(spec.key).append('\n')
+        append("label:      ").append(label).append('\n')
+        append("icon:       ").append(iconName).append('\n')
+        append("eyes-free:  ").append(spec.isEyesFreeSafe).append('\n')
+        append("surfaces:   ").append(surfaces).append('\n')
+        append("reader:     ").append(if (hasStatusReader) "wired" else "(stub — phase A)").append('\n')
+        append("status:     ").append(statusLine)
+    }
+}
+
+@Composable
+private fun DetailBox(text: String) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                RoundedCornerShape(8.dp)
+            )
+            .padding(10.dp)
+    ) {
+        Text(
+            text,
+            style = MaterialTheme.typography.bodySmall,
+            fontFamily = FontFamily.Monospace
+        )
+    }
+}
+
+/**
+ * Order matches knownDashboardMetrics. Duplicated here to keep the
+ * diagnostics module free of a settings-module dependency.
+ * TODO consolidate via a shared MetricCatalog mirror of ActionCatalog.
+ */
+private val serviceMetricKeys: List<String> = listOf(
+    "BATTERY", "TEMPERATURE", "VOLTAGE", "CURRENT", "LOAD", "TRIP",
+    "SPEED", "POWER", "ODOMETER",
+    "MOTOR_POWER", "BATTERY_POWER",
+    "BATTERY_1", "BATTERY_2",
+    "PITCH", "ROLL",
+    "G_FORCE", "LATERAL_G", "FORWARD_G",
+    "TORQUE", "DYN_SPEED_LIMIT", "DYN_CURRENT_LIMIT",
+    "MOTOR_TEMP", "CONTROLLER_TEMP", "BATTERY_TEMP",
+    "HEADROOM", "TRIP_TIME", "TRIP_MAX_SPEED", "AVG_TRIP_SPEED",
+    "WH_CONSUMED", "RANGE_ESTIMATE", "WH_PER_KM",
+    "PHONE_BATTERY", "GPS_ALTITUDE", "GPS_SPEED", "GPS_HEADING",
+    "GPS_ACCURACY",
+    "SLOPE", "ASCENT", "DESCENT", "MOTOR_RPM", "REGEN_WH",
+    "BT_RSSI"
+)
+
+/**
+ * One-line status string for an action — what does the rider see right
+ * now? Delegates to [com.eried.eucplanet.data.model.ActionSpec.statusReader]
+ * when the catalog wires one, falling back to a "no resting state" note
+ * for one-shot actions (HORN, VOICE_ANNOUNCE, MEDIA_*, RESET_TRIP).
+ */
+private fun actionStatusText(key: String, snapshot: ServiceOverlaySnapshot): String {
+    val spec = ActionCatalog.byKey(key) ?: return "(unknown action)"
+    val reader = spec.statusReader ?: return "(one-shot, no resting state)"
+    val active = reader(snapshot.toStatusContext())
+    return "active=$active"
+}
+
+/**
+ * Reverse-lookup the AccentXxx Color constants so the metric detail box
+ * can show a human-readable color name instead of raw ARGB. Falls back
+ * to a hex string if a metric uses a non-palette color.
+ */
+private fun accentLabelFor(color: androidx.compose.ui.graphics.Color): String {
+    return when (color.toArgb().toLong() and 0xFFFFFFFFL) {
+        com.eried.eucplanet.ui.theme.AccentGreen.toArgb().toLong() and 0xFFFFFFFFL -> "Green"
+        com.eried.eucplanet.ui.theme.AccentOrange.toArgb().toLong() and 0xFFFFFFFFL -> "Orange"
+        com.eried.eucplanet.ui.theme.AccentBlue.toArgb().toLong() and 0xFFFFFFFFL -> "Blue"
+        com.eried.eucplanet.ui.theme.AccentPurple.toArgb().toLong() and 0xFFFFFFFFL -> "Purple"
+        com.eried.eucplanet.ui.theme.AccentPink.toArgb().toLong() and 0xFFFFFFFFL -> "Pink"
+        else -> "#${(color.toArgb() and 0xFFFFFF).toString(16).padStart(6, '0').uppercase()}"
+    }
+}
+
+private fun rawMetricValue(key: String, wheel: WheelData): String = when (key) {
+    "BATTERY" -> wheel.batteryPercent.toString()
+    "TEMPERATURE" -> "%.1f".format(wheel.maxTemperature)
+    "VOLTAGE" -> "%.2f".format(wheel.voltage)
+    "CURRENT" -> "%.2f".format(wheel.current)
+    "LOAD" -> "%.1f".format(wheel.pwm)
+    "TRIP" -> "%.3f".format(wheel.tripDistance)
+    "SPEED" -> "%.2f".format(wheel.speed)
+    "POWER" -> "${wheel.batteryPower}"
+    "ODOMETER" -> "%.3f".format(wheel.totalDistance)
+    "MOTOR_POWER" -> "${wheel.motorPower}"
+    "BATTERY_POWER" -> "${wheel.batteryPower}"
+    "BATTERY_1" -> "%.1f".format(wheel.battery1Percent)
+    "BATTERY_2" -> "%.1f".format(wheel.battery2Percent)
+    "PITCH" -> "%.2f".format(wheel.pitchAngle)
+    "ROLL" -> "%.2f".format(wheel.rollAngle)
+    "G_FORCE" -> "%.3f".format(wheel.gForce)
+    "LATERAL_G" -> "%.3f".format(wheel.accelX)
+    "FORWARD_G" -> "%.3f".format(wheel.accelY)
+    "TORQUE" -> "%.2f".format(wheel.torque)
+    "DYN_SPEED_LIMIT" -> "%.2f".format(wheel.dynamicSpeedLimit)
+    "DYN_CURRENT_LIMIT" -> "%.2f".format(wheel.dynamicCurrentLimit)
+    "MOTOR_TEMP" -> wheel.temperatures.getOrNull(0)?.let { "%.1f".format(it) } ?: "—"
+    "CONTROLLER_TEMP" -> wheel.temperatures.getOrNull(1)?.let { "%.1f".format(it) } ?: "—"
+    "BATTERY_TEMP" -> wheel.temperatures.getOrNull(2)?.let { "%.1f".format(it) } ?: "—"
+    else -> "—"
+}
+
+private fun historyFor(key: String, history: FullMetricHistory): List<MetricSample>? = when (key) {
+    "BATTERY" -> history.battery
+    "TEMPERATURE" -> history.temperature
+    "VOLTAGE" -> history.voltage
+    "CURRENT" -> history.current
+    "LOAD" -> history.load
+    "SPEED" -> history.speed
+    else -> null
+}

--- a/app/src/main/java/com/eried/eucplanet/flic/FlicManager.kt
+++ b/app/src/main/java/com/eried/eucplanet/flic/FlicManager.kt
@@ -8,7 +8,6 @@ import android.util.Log
 import android.view.KeyEvent
 import com.eried.eucplanet.R
 import com.eried.eucplanet.data.model.AppSettings
-import com.eried.eucplanet.data.model.FlicAction
 import com.eried.eucplanet.data.repository.SettingsRepository
 import com.eried.eucplanet.data.repository.TripRepository
 import com.eried.eucplanet.data.repository.WheelRepository
@@ -248,60 +247,68 @@ class FlicManager @Inject constructor(
             else -> return
         }
 
-        val action = try {
-            FlicAction.valueOf(actionName)
-        } catch (_: Exception) {
-            FlicAction.NONE
-        }
-
-        Log.i(TAG, "Dispatching action: $action")
-        executeAction(action, settings)
+        Log.i(TAG, "Dispatching action: $actionName")
+        executeAction(actionName, settings)
     }
 
     fun dispatchActionByName(actionName: String) {
-        val action = try { FlicAction.valueOf(actionName) } catch (_: Exception) { FlicAction.NONE }
-        if (action == FlicAction.NONE) return
+        if (actionName.isEmpty() || actionName == "NONE") return
         scope.launch {
             val settings = settingsRepository.get()
-            executeAction(action, settings)
+            executeAction(actionName, settings)
         }
     }
 
-    private suspend fun executeAction(action: FlicAction, settings: AppSettings) {
-        if (action != FlicAction.NONE) _lastActionAt.value = System.currentTimeMillis()
-        when (action) {
-            FlicAction.NONE -> {}
-            FlicAction.HORN -> wheelRepository.sendHorn()
-            FlicAction.LIGHT_TOGGLE -> {
+    /**
+     * Executes the action identified by [key]. Unknown / blank / "NONE" keys
+     * are no-ops. The dispatch table below is the SINGLE source of behavior
+     * for every physical surface (Flic, volume key, watch) — adding a new
+     * action means:
+     *   1. Append to [com.eried.eucplanet.data.model.ActionCatalog.all] (metadata)
+     *   2. Add a branch here (behavior)
+     * That's it — no other file in the action layer needs to grow.
+     *
+     * Dashboard-only actions (OPEN_*, MUTE_ALARMS, RESET_TRIP, TOGGLE_UNITS)
+     * route through a different executor in the UI layer because they need
+     * navigation / Snackbar / Compose handles this service doesn't have.
+     */
+    private suspend fun executeAction(key: String, settings: AppSettings) {
+        if (key.isEmpty() || key == "NONE") return
+        _lastActionAt.value = System.currentTimeMillis()
+        Log.d(TAG, "executeAction key=$key")
+        when (key) {
+            "HORN" -> wheelRepository.sendHorn()
+            "LIGHT_TOGGLE" -> {
                 automationManager.notifyManualLightChange()
                 wheelRepository.toggleLight()
             }
-            FlicAction.LOCK_TOGGLE -> wheelRepository.toggleLock()
-            FlicAction.SAFETY_TOGGLE -> wheelRepository.toggleSafetySpeed()
-            FlicAction.SAFETY_ON -> wheelRepository.enableSafetySpeed()
-            FlicAction.SAFETY_OFF -> wheelRepository.disableSafetySpeed()
-            FlicAction.VOICE_ANNOUNCE -> {
+            "LOCK_TOGGLE" -> wheelRepository.toggleLock()
+            "SAFETY_TOGGLE" -> wheelRepository.toggleSafetySpeed()
+            "SAFETY_ON" -> wheelRepository.enableSafetySpeed()
+            "SAFETY_OFF" -> wheelRepository.disableSafetySpeed()
+            "VOICE_ANNOUNCE" -> {
                 voiceService.announceTrigger(
                     wheelRepository.wheelData.value, settings,
                     isRecording = tripRepository.recording.value
                 )
             }
-            FlicAction.RECORD_TOGGLE -> {
+            "RECORD_TOGGLE" -> {
                 if (tripRepository.recording.value) {
                     tripRepository.stopRecording()
                 } else {
                     tripRepository.startRecording()
                 }
             }
-            FlicAction.RECORD_START -> {
+            "RECORD_START" -> {
                 if (!tripRepository.recording.value) tripRepository.startRecording()
             }
-            FlicAction.RECORD_STOP -> {
+            "RECORD_STOP" -> {
                 if (tripRepository.recording.value) tripRepository.stopRecording()
             }
-            FlicAction.MEDIA_PLAY_PAUSE -> sendMediaKey(KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE)
-            FlicAction.MEDIA_NEXT -> sendMediaKey(KeyEvent.KEYCODE_MEDIA_NEXT)
-            FlicAction.MEDIA_PREVIOUS -> sendMediaKey(KeyEvent.KEYCODE_MEDIA_PREVIOUS)
+            "MEDIA_PLAY_PAUSE" -> sendMediaKey(KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE)
+            "MEDIA_NEXT" -> sendMediaKey(KeyEvent.KEYCODE_MEDIA_NEXT)
+            "MEDIA_PREVIOUS" -> sendMediaKey(KeyEvent.KEYCODE_MEDIA_PREVIOUS)
+            else -> Log.w(TAG, "Unknown / unsupported action key for physical surface: $key")
         }
     }
 

--- a/app/src/main/java/com/eried/eucplanet/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/eried/eucplanet/ui/dashboard/DashboardScreen.kt
@@ -22,7 +22,9 @@ import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.ui.draw.rotate
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import androidx.compose.foundation.Canvas
@@ -136,6 +138,8 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.eried.eucplanet.R
 import com.eried.eucplanet.ble.ConnectionState
+import com.eried.eucplanet.data.model.MetricCatalog
+import com.eried.eucplanet.data.model.SparklineStyle
 import com.eried.eucplanet.data.model.arrowAngleDeg
 import com.eried.eucplanet.ui.navigator.NavigationOverlayViewModel
 import com.eried.eucplanet.ui.theme.AccentBlue
@@ -208,15 +212,10 @@ fun DashboardScreen(
     val tiltbackSpeed by viewModel.tiltbackSpeed.collectAsState()
     val safetyTiltbackSpeed by viewModel.safetyTiltbackSpeed.collectAsState()
     val realHistory by viewModel.history.collectAsState()
-    // Show demo sparklines when disconnected so the feature is visible
-    val history = if (realHistory.battery.size >= 2) realHistory else MetricHistory(
-        battery = listOf(85f, 84f, 83f, 84f, 82f, 80f, 79f, 78f, 77f, 78f, 76f, 75f, 74f, 73f, 72f),
-        temperature = listOf(32f, 33f, 34f, 35f, 36f, 37f, 38f, 37f, 36f, 38f, 39f, 40f, 41f, 40f, 39f),
-        voltage = listOf(98f, 97.5f, 97f, 96.5f, 97f, 96f, 95.5f, 95f, 96f, 95f, 94.5f, 94f, 93.5f, 94f, 93f),
-        current = listOf(2f, 5f, 12f, 8f, 3f, 15f, 20f, 10f, 4f, 8f, 18f, 6f, 3f, 7f, 11f),
-        load = listOf(5f, 12f, 25f, 18f, 8f, 35f, 50f, 30f, 10f, 20f, 45f, 15f, 8f, 22f, 28f),
-        speed = emptyList()
-    )
+    // No fake disconnected demo. The dashboard shows real samples only —
+    // sparklines remain empty until the wheel sends at least 2 frames,
+    // matching the per-catalog metric behavior we adopted in Phase 2.
+    val history = realHistory
     val modelName by viewModel.modelName.collectAsState()
     val connectedDeviceName by viewModel.connectedDeviceName.collectAsState()
     val connectedBrand by viewModel.connectedBrand.collectAsState()
@@ -239,6 +238,21 @@ fun DashboardScreen(
     val gaugeOrangePct by viewModel.gaugeOrangePct.collectAsState()
     val gaugeRedPct by viewModel.gaugeRedPct.collectAsState()
     val currentMode by viewModel.currentDisplayMode.collectAsState()
+    // Customizable dashboard layout — falls back to the catalog defaults
+    // (BATTERY, TEMPERATURE, VOLTAGE, CURRENT, LOAD, TRIP) when the
+    // saved order is blank or has fewer than 6 entries.
+    val dashboardMetricOrderRaw by viewModel.dashboardMetricOrder.collectAsState()
+    val dashboardMetricStatsJson by viewModel.dashboardMetricStats.collectAsState()
+    val dashboardMetricsColumnsSetting by viewModel.dashboardMetricsColumns.collectAsState()
+    val dashboardCompositesJson by viewModel.dashboardCompositeMetrics.collectAsState()
+    val dashboardCustomTilesJson by viewModel.dashboardCustomTiles.collectAsState()
+    val dashboardActionOrderRaw by viewModel.dashboardActionOrder.collectAsState()
+    val dashboardActionGroupsJson by viewModel.dashboardActionGroups.collectAsState()
+    // Phone-battery and GPS feeds for the catalog metrics that aren't
+    // sourced from WheelData. Both update lazily; the value pipeline
+    // just reads the latest StateFlow snapshot on each recomposition.
+    val phoneBatteryPct by viewModel.phoneBatteryPercent.collectAsState()
+    val gpsLocation by viewModel.currentLocation.collectAsState()
     val hasFlic by viewModel.hasFlicConfigured.collectAsState()
     // Navigation state, drives the dashboard's navigator button (the singleton
     // engine behind this VM is shared with the floating navigation overlay).
@@ -255,6 +269,12 @@ fun DashboardScreen(
     var showNoTripsDialog by remember { mutableStateOf(false) }
     var showSourcesSheet by remember { mutableStateOf(false) }
     var showSettingsMenu by remember { mutableStateOf(false) }
+    // Lifted from the bottom-info-row block so OPEN_ABOUT (when bound
+    // to an action grid slot) can open the same dialog the version-text
+    // tap opens.
+    var showAboutDialog by remember { mutableStateOf(false) }
+    var showDiagnosticsDialog by remember { mutableStateOf(false) }
+    var showDiagnosticsConfirm by remember { mutableStateOf(false) }
     var showMapMenu by remember { mutableStateOf(false) }
     var showStudioMenu by remember { mutableStateOf(false) }
     var showGpsMenu by remember { mutableStateOf(false) }
@@ -814,96 +834,403 @@ fun DashboardScreen(
             // fields at the WheelData defaults (0). Showing "0%" or "0.0V"
             // looks like a real reading; the placeholder makes it obvious
             // we're waiting for the wheel to talk.
-            val batteryCard: @Composable RowScope.() -> Unit = {
-                StatCard(stringResource(R.string.stat_battery),
-                    if (live && wheelData.batteryPercent > 0)
-                        "${wheelData.batteryPercent}%" else placeholder,
-                    battColor, history.battery, Modifier.weight(1f),
-                    onClick = { onNavigateToMetric("BATTERY") })
+            // Read the rider's customized metric order. Falls back to
+            // the catalog defaults (BATTERY, TEMPERATURE, VOLTAGE,
+            // CURRENT, LOAD, TRIP) when blank or short — guarantees the
+            // out-of-box layout is byte-identical to the old hardcoded
+            // 6-card grid.
+            val activeMetricKeys = remember(dashboardMetricOrderRaw) {
+                val parsed = dashboardMetricOrderRaw.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+                val defaults = listOf("BATTERY", "TEMPERATURE", "VOLTAGE", "CURRENT", "LOAD", "TRIP")
+                (parsed + defaults).distinct().take(6)
             }
-            val tempCard: @Composable RowScope.() -> Unit = {
-                // Show the placeholder when the parser couldn't decode a
-                // motor reading (maxTemperature stays at 0). Without this,
-                // imperial users see "32°F", the °F equivalent of 0°C , 
-                // which looks like a real reading and "sticks" until the
-                // next valid frame.
-                val tempUnknown = wheelData.maxTemperature <= 0f
-                StatCard(stringResource(R.string.stat_temp),
-                    if (live && !tempUnknown) "%.0f%s".format(tempValue, tempUnitLabel) else placeholder,
-                    tempColor, history.temperature, Modifier.weight(1f),
-                    onClick = { onNavigateToMetric("TEMPERATURE") })
-            }
-            val voltageCard: @Composable RowScope.() -> Unit = {
-                StatCard(stringResource(R.string.stat_voltage),
-                    if (live && wheelData.voltage > 0f)
-                        "%.1fV".format(wheelData.voltage) else placeholder,
-                    primary, history.voltage, Modifier.weight(1f),
-                    onClick = { onNavigateToMetric("VOLTAGE") })
-            }
-            val currentCard: @Composable RowScope.() -> Unit = {
-                StatCard(
-                    if (showWatts) wattsLabel else ampsLabel,
-                    currentText,
-                    if (live && wheelData.current > 20) AccentOrange else primary,
-                    history.current,
-                    Modifier.weight(1f),
-                    onClick = { onNavigateToMetric("CURRENT") },
-                    onLongClick = { viewModel.toggleCurrentDisplayMode() }
-                )
-            }
-            val loadCard: @Composable RowScope.() -> Unit = {
-                StatCard(stringResource(R.string.stat_load),
-                    if (live) "%.0f%%".format(pwm) else placeholder,
-                    loadColor, history.load, Modifier.weight(1f),
-                    onClick = { onNavigateToMetric("LOAD") })
-            }
-            val tripCard: @Composable RowScope.() -> Unit = {
-                StatCard(stringResource(R.string.stat_trip),
-                    if (live) "%.1f %s".format(tripValue, distUnit) else placeholder,
-                    primary, emptyList(), Modifier.weight(1f),
-                    onClick = {
-                        val targetTripId = currentTripId ?: latestTripId
-                        if (targetTripId != null) onNavigateToTripDetail(targetTripId)
-                        else showNoTripsDialog = true
-                    })
+            // Tablets force 3 columns to honour wideStats. Phones use
+            // whatever the rider set in the editor (2 or 3).
+            val metricColumns = if (wideStats) 3
+                else dashboardMetricsColumnsSetting.coerceIn(2, 3)
+            val metricRows = (activeMetricKeys.size + metricColumns - 1) / metricColumns
+
+            // Per-slot sparkline-enabled flag. JSON shape mirrors
+            // SettingsViewModel.parseSlotStats: { "<KEY>": { "spark": Bool, "l": Stat, "r": Stat } }
+            // Sparkline defaults to true so unconfigured tiles match
+            // today's always-on rendering.
+            fun sparkEnabledFor(key: String): Boolean = try {
+                val root = org.json.JSONObject(dashboardMetricStatsJson.ifBlank { "{}" })
+                root.optJSONObject(key)?.optBoolean("spark", true) ?: true
+            } catch (_: Exception) { true }
+
+            // Per-slot value resolver — turns any metric key into its
+            // current displayable value. Reused by composite tiles to
+            // populate each of their 2-3 cells. Static metric formatting
+            // mirrors the default-6 cards above; new metric keys fall
+            // back to placeholder until their value path lands.
+            fun displayValueFor(metricKey: String): String {
+                if (!live) return placeholder
+                return when (metricKey) {
+                    "BATTERY" -> if (wheelData.batteryPercent > 0) "${wheelData.batteryPercent}%" else placeholder
+                    "TEMPERATURE" -> if (wheelData.maxTemperature > 0f)
+                        "%.0f%s".format(tempValue, tempUnitLabel) else placeholder
+                    "VOLTAGE" -> if (wheelData.voltage > 0f) "%.1fV".format(wheelData.voltage) else placeholder
+                    "CURRENT" -> currentText
+                    "LOAD" -> "%.0f%%".format(pwm)
+                    "TRIP" -> "%.1f %s".format(tripValue, distUnit)
+                    "SPEED" -> "%.0f".format(wheelData.speed)
+                    "POWER", "BATTERY_POWER" -> "${wheelData.batteryPower}W"
+                    "MOTOR_POWER" -> "${wheelData.motorPower}W"
+                    "ODOMETER" -> "%.1f %s".format(
+                        com.eried.eucplanet.util.Units.distance(wheelData.totalDistance, distanceUnit),
+                        distUnit
+                    )
+                    "BATTERY_1" -> if (wheelData.battery1Percent > 0f) "%.0f%%".format(wheelData.battery1Percent) else placeholder
+                    "BATTERY_2" -> if (wheelData.battery2Percent > 0f) "%.0f%%".format(wheelData.battery2Percent) else placeholder
+                    "PITCH" -> "%.1f°".format(wheelData.pitchAngle)
+                    "ROLL" -> "%.1f°".format(wheelData.rollAngle)
+                    "G_FORCE" -> "%.2fg".format(wheelData.gForce)
+                    "LATERAL_G" -> "%.2fg".format(wheelData.accelX)
+                    "FORWARD_G" -> "%.2fg".format(wheelData.accelY)
+                    "TORQUE" -> "%.1fNm".format(wheelData.torque)
+                    "DYN_SPEED_LIMIT" -> if (wheelData.dynamicSpeedLimit > 0f)
+                        "%.0f".format(wheelData.dynamicSpeedLimit) else placeholder
+                    "DYN_CURRENT_LIMIT" -> if (wheelData.dynamicCurrentLimit > 0f)
+                        "%.1fA".format(wheelData.dynamicCurrentLimit) else placeholder
+                    "MOTOR_TEMP" -> wheelData.temperatures.getOrNull(0)?.let { "%.0f%s".format(
+                        com.eried.eucplanet.util.Units.temperature(it, tempUnit), tempUnitLabel
+                    ) } ?: placeholder
+                    "CONTROLLER_TEMP" -> wheelData.temperatures.getOrNull(1)?.let { "%.0f%s".format(
+                        com.eried.eucplanet.util.Units.temperature(it, tempUnit), tempUnitLabel
+                    ) } ?: placeholder
+                    "BATTERY_TEMP" -> wheelData.temperatures.getOrNull(2)?.let { "%.0f%s".format(
+                        com.eried.eucplanet.util.Units.temperature(it, tempUnit), tempUnitLabel
+                    ) } ?: placeholder
+                    "PHONE_BATTERY" -> if (phoneBatteryPct in 0..100) "$phoneBatteryPct%" else placeholder
+                    "GPS_ALTITUDE" -> gpsLocation?.altitude?.let { alt ->
+                        "%.0fm".format(alt.toFloat())
+                    } ?: placeholder
+                    "GPS_SPEED" -> gpsLocation?.let { loc ->
+                        if (loc.hasSpeed()) "%.1f".format(loc.speed * 3.6f) else placeholder
+                    } ?: placeholder
+                    "GPS_HEADING" -> gpsLocation?.let { loc ->
+                        if (loc.hasBearing()) "%.0f°".format(loc.bearing) else placeholder
+                    } ?: placeholder
+                    "GPS_ACCURACY" -> gpsLocation?.let { loc ->
+                        if (loc.hasAccuracy()) "%.0fm".format(loc.accuracy) else placeholder
+                    } ?: placeholder
+                    // SLOPE / ASCENT / DESCENT need integrated altitude
+                    // history (not yet wired). MOTOR_RPM / REGEN_WH /
+                    // BT_RSSI aren't surfaced on WheelData today — those
+                    // need adapter-side plumbing. Placeholder for now.
+                    else -> placeholder
+                }
             }
 
-            // Foldables / tablets: 3 columns × 2 rows. Phones: 2 columns × 3 rows.
-            if (wideStats) {
+            // Lookup composite definition by id from the JSON blob the
+            // editor writes. Returns null if the id isn't found (which
+            // means the rider deleted it but the order entry still
+            // points at it — render an empty placeholder in that case).
+            fun compositeFor(id: String): com.eried.eucplanet.ui.settings.MetricComposite? = try {
+                val root = org.json.JSONObject(dashboardCompositesJson.ifBlank { "{}" })
+                val node = root.optJSONObject(id) ?: return@compositeFor null
+                val layout = runCatching {
+                    com.eried.eucplanet.ui.settings.CompositeLayout.valueOf(
+                        node.optString("layout", com.eried.eucplanet.ui.settings.CompositeLayout.ROW2.name)
+                    )
+                }.getOrDefault(com.eried.eucplanet.ui.settings.CompositeLayout.ROW2)
+                val cellsArr = node.optJSONArray("cells")
+                val cells = if (cellsArr != null) {
+                    (0 until cellsArr.length()).mapNotNull {
+                        cellsArr.optString(it).takeIf { s -> s.isNotEmpty() }
+                    }
+                } else emptyList()
+                val statsArr = node.optJSONArray("cellStats")
+                val cellStats: List<com.eried.eucplanet.ui.settings.DashboardStat> = if (statsArr != null) {
+                    (0 until statsArr.length()).map { idx ->
+                        runCatching {
+                            com.eried.eucplanet.ui.settings.DashboardStat.valueOf(
+                                statsArr.optString(idx, com.eried.eucplanet.ui.settings.DashboardStat.CURRENT.name)
+                            )
+                        }.getOrDefault(com.eried.eucplanet.ui.settings.DashboardStat.CURRENT)
+                    }
+                } else List(cells.size) { com.eried.eucplanet.ui.settings.DashboardStat.CURRENT }
+                com.eried.eucplanet.ui.settings.MetricComposite(layout, cells, cellStats)
+            } catch (_: Exception) { null }
+
+            fun customTileFor(id: String): com.eried.eucplanet.ui.settings.CustomTile? = try {
+                val root = org.json.JSONObject(dashboardCustomTilesJson.ifBlank { "{}" })
+                val node = root.optJSONObject(id) ?: return@customTileFor null
+                val text = node.optString("text", "")
+                val icon = node.optString("icon", "")
+                val url = node.optString("url", "")
+                val action = runCatching {
+                    com.eried.eucplanet.ui.settings.CustomTileAction.valueOf(
+                        node.optString("action", com.eried.eucplanet.ui.settings.CustomTileAction.NONE.name)
+                    )
+                }.getOrDefault(com.eried.eucplanet.ui.settings.CustomTileAction.NONE)
+                com.eried.eucplanet.ui.settings.CustomTile(text, icon, action, url)
+            } catch (_: Exception) { null }
+
+            for (rowIdx in 0 until metricRows) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    batteryCard(); tempCard(); voltageCard()
+                    for (colIdx in 0 until metricColumns) {
+                        val slotIdx = rowIdx * metricColumns + colIdx
+                        val key = activeMetricKeys.getOrNull(slotIdx)
+                        if (key == null) {
+                            Box(modifier = Modifier.weight(1f))
+                            continue
+                        }
+                        val spec = MetricCatalog.byKey(key)
+                        val sparklineEnabled = sparkEnabledFor(key)
+                        // Per-key value / colour / click ingredients.
+                        // The default 6 keys preserve every quirk of the
+                        // old StatCard era — long-press on CURRENT toggles
+                        // A↔W, tap on TRIP opens the latest trip detail.
+                        // New / customized keys still render via the
+                        // catalog with a placeholder value where the
+                        // dashboard hasn't extended the value path yet.
+                        when (key) {
+                            "BATTERY" -> LiveMetricTile(
+                                label = stringResource(R.string.stat_battery),
+                                value = if (live && wheelData.batteryPercent > 0)
+                                    "${wheelData.batteryPercent}%" else placeholder,
+                                accent = battColor,
+                                sparkData = history.battery,
+                                sparkStyle = spec?.sparkline ?: SparklineStyle.AREA,
+                                sparklineEnabled = sparklineEnabled,
+                                bipolarBaseline = spec?.bipolarBaseline ?: 0f,
+                                bipolarNegativeAccent = spec?.bipolarNegativeAccent,
+                                modifier = Modifier.weight(1f),
+                                onClick = { onNavigateToMetric("BATTERY") }
+                            )
+                            "TEMPERATURE" -> {
+                                val tempUnknown = wheelData.maxTemperature <= 0f
+                                LiveMetricTile(
+                                    label = stringResource(R.string.stat_temp),
+                                    value = if (live && !tempUnknown)
+                                        "%.0f%s".format(tempValue, tempUnitLabel) else placeholder,
+                                    accent = tempColor,
+                                    sparkData = history.temperature,
+                                    sparkStyle = spec?.sparkline ?: SparklineStyle.AREA,
+                                    sparklineEnabled = sparklineEnabled,
+                                    modifier = Modifier.weight(1f),
+                                    onClick = { onNavigateToMetric("TEMPERATURE") }
+                                )
+                            }
+                            "VOLTAGE" -> LiveMetricTile(
+                                label = stringResource(R.string.stat_voltage),
+                                value = if (live && wheelData.voltage > 0f)
+                                    "%.1fV".format(wheelData.voltage) else placeholder,
+                                accent = primary,
+                                sparkData = history.voltage,
+                                sparkStyle = spec?.sparkline ?: SparklineStyle.LINE,
+                                sparklineEnabled = sparklineEnabled,
+                                modifier = Modifier.weight(1f),
+                                onClick = { onNavigateToMetric("VOLTAGE") }
+                            )
+                            "CURRENT" -> LiveMetricTile(
+                                label = if (showWatts) wattsLabel else ampsLabel,
+                                value = currentText,
+                                accent = if (live && wheelData.current > 20) AccentOrange else primary,
+                                sparkData = history.current,
+                                sparkStyle = spec?.sparkline ?: SparklineStyle.AREA_BIPOLAR,
+                                sparklineEnabled = sparklineEnabled,
+                                bipolarBaseline = spec?.bipolarBaseline ?: 0f,
+                                bipolarNegativeAccent = spec?.bipolarNegativeAccent ?: AccentGreen,
+                                modifier = Modifier.weight(1f),
+                                onClick = { onNavigateToMetric("CURRENT") },
+                                onLongClick = { viewModel.toggleCurrentDisplayMode() }
+                            )
+                            "LOAD" -> LiveMetricTile(
+                                label = stringResource(R.string.stat_load),
+                                value = if (live) "%.0f%%".format(pwm) else placeholder,
+                                accent = loadColor,
+                                sparkData = history.load,
+                                sparkStyle = spec?.sparkline ?: SparklineStyle.AREA,
+                                sparklineEnabled = sparklineEnabled,
+                                modifier = Modifier.weight(1f),
+                                onClick = { onNavigateToMetric("LOAD") }
+                            )
+                            "TRIP" -> LiveMetricTile(
+                                label = stringResource(R.string.stat_trip),
+                                value = if (live) "%.1f %s".format(tripValue, distUnit) else placeholder,
+                                accent = primary,
+                                sparkData = emptyList(),
+                                sparkStyle = SparklineStyle.NONE,
+                                sparklineEnabled = false,
+                                modifier = Modifier.weight(1f),
+                                onClick = {
+                                    val targetTripId = currentTripId ?: latestTripId
+                                    if (targetTripId != null) onNavigateToTripDetail(targetTripId)
+                                    else showNoTripsDialog = true
+                                }
+                            )
+                            else -> when {
+                                // Composite metric instance — render via
+                                // the shared CompositeMetricBody so the
+                                // live dashboard, the editor preview,
+                                // and the pool pill all draw the tile
+                                // the same way. Cell values come from
+                                // displayValueFor so each sub-metric
+                                // gets the same formatting it would in
+                                // a standalone slot.
+                                key.startsWith("M:") -> {
+                                    val composite = compositeFor(key)
+                                    // Tap-side detection: derive which
+                                    // cell the rider hit so the History
+                                    // popup opens on that cell's tab.
+                                    // COL3 splits horizontally into
+                                    // thirds, COL2 in halves, ROW2 splits
+                                    // vertically. Tap position is the
+                                    // only signal; long-press still goes
+                                    // through the drag controller above.
+                                    val allCells = remember(composite) {
+                                        composite?.cells?.filter { it.isNotBlank() }.orEmpty()
+                                    }
+                                    val tappedCellIndex = remember { mutableStateOf(0) }
+                                    val tileSize = remember { mutableStateOf(androidx.compose.ui.unit.IntSize.Zero) }
+                                    fun openTabsStartingAt(cellIdx: Int) {
+                                        if (allCells.isEmpty()) {
+                                            onNavigateToMetric(key)
+                                            return
+                                        }
+                                        val safeIdx = cellIdx.coerceIn(0, allCells.lastIndex)
+                                        // Keep the original cell order so
+                                        // the History tab strip looks the
+                                        // same whichever cell the rider
+                                        // tapped. The "|<index>" suffix
+                                        // tells the History screen which
+                                        // tab to pre-select.
+                                        val payload = allCells.joinToString(",") + "|" + safeIdx
+                                        onNavigateToMetric(payload)
+                                    }
+                                    // Per-cell renderer: applies the
+                                    // cell's chosen stat (Now / Min /
+                                    // Max / Avg / percentiles) over the
+                                    // matching history buffer when
+                                    // available. CURRENT short-circuits
+                                    // to displayValueFor for live wheel
+                                    // values; computed stats render with
+                                    // no unit suffix because the buffer
+                                    // values are already in display
+                                    // units (BATTERY %, etc.).
+                                    val historySnapshot = history
+                                    val cellRenderer: (String) -> String =
+                                        cellRenderer@ { metricKey ->
+                                            // Default path = whatever
+                                            // the stat-less renderer
+                                            // would have produced. The
+                                            // body iterates by key so
+                                            // we look up which cell
+                                            // index this key occupies
+                                            // and apply that cell's
+                                            // selected stat.
+                                            if (composite == null) return@cellRenderer displayValueFor(metricKey)
+                                            val cellIdx = composite.cells.indexOf(metricKey)
+                                            val stat = composite.cellStats.getOrNull(cellIdx)
+                                                ?: com.eried.eucplanet.ui.settings.DashboardStat.CURRENT
+                                            if (stat == com.eried.eucplanet.ui.settings.DashboardStat.CURRENT) {
+                                                return@cellRenderer displayValueFor(metricKey)
+                                            }
+                                            val buf = when (metricKey) {
+                                                "BATTERY" -> historySnapshot.battery
+                                                "TEMPERATURE" -> historySnapshot.temperature
+                                                "VOLTAGE" -> historySnapshot.voltage
+                                                "CURRENT" -> historySnapshot.current
+                                                "LOAD" -> historySnapshot.load
+                                                "SPEED" -> historySnapshot.speed
+                                                else -> emptyList()
+                                            }
+                                            if (buf.size < 2) return@cellRenderer placeholder
+                                            val samples = buf.mapIndexed { idx, v ->
+                                                com.eried.eucplanet.data.repository.MetricSample(idx.toLong(), v)
+                                            }
+                                            val value = com.eried.eucplanet.ui.settings.computeDashboardStatValue(
+                                                stat, samples, fallbackCurrent = buf.last()
+                                            ) ?: return@cellRenderer placeholder
+                                            "%.1f".format(value)
+                                        }
+                                    Box(
+                                        modifier = Modifier
+                                            .weight(1f)
+                                            .height(61.dp)
+                                            .clip(RoundedCornerShape(10.dp))
+                                            .background(MaterialTheme.colorScheme.surfaceVariant)
+                                            .onGloballyPositioned { coords ->
+                                                tileSize.value = coords.size
+                                            }
+                                            .pointerInput(composite?.layout, allCells) {
+                                                detectTapGestures { offset ->
+                                                    val sz = tileSize.value
+                                                    if (sz.width == 0 || sz.height == 0 || allCells.isEmpty()) {
+                                                        openTabsStartingAt(0); return@detectTapGestures
+                                                    }
+                                                    val idx = when (composite?.layout) {
+                                                        com.eried.eucplanet.ui.settings.CompositeLayout.COL3 -> {
+                                                            val third = sz.width / 3f
+                                                            (offset.x / third).toInt().coerceIn(0, 2)
+                                                        }
+                                                        com.eried.eucplanet.ui.settings.CompositeLayout.COL2 -> {
+                                                            if (offset.x < sz.width / 2f) 0 else 1
+                                                        }
+                                                        com.eried.eucplanet.ui.settings.CompositeLayout.ROW2 -> {
+                                                            if (offset.y < sz.height / 2f) 0 else 1
+                                                        }
+                                                        else -> 0
+                                                    }
+                                                    tappedCellIndex.value = idx
+                                                    openTabsStartingAt(idx)
+                                                }
+                                            }
+                                    ) {
+                                        if (composite != null) {
+                                            com.eried.eucplanet.ui.settings.CompositeMetricBody(
+                                                composite = composite,
+                                                valueOf = cellRenderer
+                                            )
+                                        }
+                                    }
+                                }
+                                // Custom tile — rider's icon + text label.
+                                key.startsWith("C:") -> {
+                                    val tile = customTileFor(key)
+                                    Box(
+                                        modifier = Modifier
+                                            .weight(1f)
+                                            .height(61.dp)
+                                            .clip(RoundedCornerShape(10.dp))
+                                            .background(MaterialTheme.colorScheme.surfaceVariant)
+                                            .clickable { onNavigateToMetric(key) }
+                                    ) {
+                                        if (tile != null) {
+                                            com.eried.eucplanet.ui.settings.CustomTileBody(tile)
+                                        }
+                                    }
+                                }
+                                else -> {
+                                    // Catalog-driven generic rendering
+                                    // for any other static metric the
+                                    // rider drops into a slot. Value
+                                    // pipeline for these keys is wired in
+                                    // a follow-up.
+                                    LiveMetricTile(
+                                        label = spec?.let { stringResource(it.labelRes) } ?: key,
+                                        value = displayValueFor(key),
+                                        accent = spec?.accent ?: primary,
+                                        sparkData = emptyList(),
+                                        sparkStyle = spec?.sparkline ?: SparklineStyle.NONE,
+                                        sparklineEnabled = sparklineEnabled,
+                                        bipolarBaseline = spec?.bipolarBaseline ?: 0f,
+                                        bipolarNegativeAccent = spec?.bipolarNegativeAccent,
+                                        modifier = Modifier.weight(1f),
+                                        onClick = { onNavigateToMetric(key) }
+                                    )
+                                }
+                            }
+                        }
+                    }
                 }
-                Spacer(Modifier.height(10.dp))
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    currentCard(); loadCard(); tripCard()
-                }
-            } else {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    batteryCard(); tempCard()
-                }
-                Spacer(Modifier.height(10.dp))
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    voltageCard(); currentCard()
-                }
-                Spacer(Modifier.height(10.dp))
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    loadCard(); tripCard()
-                }
+                if (rowIdx < metricRows - 1) Spacer(Modifier.height(10.dp))
             }
 
             Spacer(Modifier.height(14.dp))
@@ -913,161 +1240,294 @@ fun DashboardScreen(
             val actionAspect: Float? = null
             val actionHeight: Int? = if (wideStats) 88 else 104
 
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                ActionButton(Icons.Default.Campaign, stringResource(R.string.action_horn),
-                    enabled = connectionState == ConnectionState.CONNECTED,
-                    onClick = { viewModel.onHornPress() },
-                    modifier = Modifier.weight(1f),
-                    aspectRatio = actionAspect, heightDp = actionHeight)
-                ActionTile(
-                    modifier = Modifier.weight(1f),
-                    icon = Icons.Default.FlashlightOn,
-                    label = stringResource(R.string.action_light),
-                    active = wheelData.lightOn,
-                    activeColor = if (useAccent) primary else AccentYellow,
-                    enabled = connectionState == ConnectionState.CONNECTED && !lightBusy,
-                    onClick = { viewModel.onLightToggle() },
-                    aspectRatio = actionAspect, heightDp = actionHeight,
-                    menu = { dismiss ->
-                        DropdownMenuItem(
-                            text = { Text(stringResource(R.string.menu_auto_lights)) },
-                            onClick = { dismiss(); onNavigateToSettings(6) }
-                        )
-                    }
+            // Read the rider's customized action order. Falls back to the
+            // catalog defaults (HORN / LIGHT / VOICE / SAFETY / LOCK /
+            // RECORD) when blank — out-of-box layout stays byte-identical
+            // to the old hardcoded 6-button arrangement.
+            val activeActionKeys = remember(dashboardActionOrderRaw) {
+                val parsed = dashboardActionOrderRaw.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+                val defaults = listOf(
+                    "HORN", "LIGHT_TOGGLE", "VOICE_ANNOUNCE",
+                    "SAFETY_TOGGLE", "LOCK_TOGGLE", "RECORD_TOGGLE"
                 )
-                val periodicVoiceOn by viewModel.voicePeriodicEnabled.collectAsState()
-                ActionTile(
-                    modifier = Modifier.weight(1f),
-                    icon = Icons.Default.RecordVoiceOver,
-                    label = stringResource(R.string.action_voice),
-                    onClick = { viewModel.onVoiceAnnounce() },
-                    aspectRatio = actionAspect, heightDp = actionHeight,
-                    menu = { dismiss ->
-                        DropdownMenuItem(
-                            text = { Text(stringResource(R.string.tab_voice)) },
-                            onClick = { dismiss(); onNavigateToSettings(3) }
-                        )
-                        DropdownMenuItem(
-                            text = { Text(stringResource(R.string.tab_alarms)) },
-                            onClick = { dismiss(); onNavigateToSettings(5) }
-                        )
-                        androidx.compose.material3.HorizontalDivider(
-                            color = MaterialTheme.colorScheme.outline.copy(alpha = 0.2f)
-                        )
-                        DropdownMenuItem(
-                            text = {
-                                Text(
-                                    if (periodicVoiceOn) stringResource(R.string.menu_voice_periodic_off)
-                                    else stringResource(R.string.menu_voice_periodic_on)
-                                )
-                            },
-                            onClick = { dismiss(); viewModel.toggleVoicePeriodic() }
-                        )
-                    }
-                )
+                (parsed + defaults).distinct().take(6)
             }
+            val periodicVoiceOn by viewModel.voicePeriodicEnabled.collectAsState()
+            val lockAtAnySpeed by viewModel.cheatState.lockAtAnySpeed.collectAsState()
+            val lockBlockedBySpeed = !locked && kotlin.math.abs(wheelData.speed) >= 5f && !lockAtAnySpeed
 
-            Spacer(Modifier.height(8.dp))
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                ActionTile(
-                    modifier = Modifier.weight(1f),
-                    icon = Icons.Default.Shield,
-                    label = if (safetyActive) stringResource(R.string.action_legal_on) else stringResource(R.string.action_legal_mode),
-                    active = safetyActive,
-                    activeColor = if (useAccent) primary else AccentOrange,
-                    enabled = connectionState == ConnectionState.CONNECTED,
-                    onClick = { viewModel.onSafetySpeedToggle() },
-                    aspectRatio = actionAspect, heightDp = actionHeight,
-                    menu = { dismiss ->
-                        DropdownMenuItem(
-                            text = { Text(stringResource(R.string.section_legal_mode_speed)) },
-                            onClick = { dismiss(); onNavigateToSettings(2) }
-                        )
-                    }
-                )
-                // Lock direction is hard-blocked above LOCK_MAX_SPEED_KMH in
-                // the repository (covers Flic / watch / volume keys / dash).
-                // The button used to mirror that gate visually, but the
-                // resulting enable/disable flicker as the rider drifts around
-                // 5 km/h was distracting. Keep the button enabled and let the
-                // tap surface a toast when the wheel is in motion, the
-                // repository still refuses the actual lock.
-                val lockAtAnySpeed by viewModel.cheatState.lockAtAnySpeed.collectAsState()
-                val lockBlockedBySpeed = !locked && kotlin.math.abs(wheelData.speed) >= 5f && !lockAtAnySpeed
-                ActionButton(
-                    if (locked) Icons.Default.Lock else Icons.Default.LockOpen,
-                    if (locked) stringResource(R.string.action_locked) else stringResource(R.string.action_lock_wheel),
-                    active = locked, activeColor = if (useAccent) primary else AccentRed,
-                    enabled = connectionState == ConnectionState.CONNECTED && !lockBusy,
-                    onClick = {
-                        if (lockBlockedBySpeed) {
-                            val msg = toastContext.getString(R.string.lock_blocked_in_motion_toast)
-                            snackbarScope.launch { snackbar.showSnackbar(msg) }
-                        } else {
-                            viewModel.onLockToggle()
+            // Two rows of 3 — match today's layout. Tablets (wideStats)
+            // and phones both render 3 columns; only the height changes.
+            for (rowIdx in 0 until 2) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    for (colIdx in 0 until 3) {
+                        val slotIdx = rowIdx * 3 + colIdx
+                        val key = activeActionKeys.getOrNull(slotIdx)
+                        if (key == null) {
+                            Box(modifier = Modifier.weight(1f))
+                            continue
                         }
-                    },
-                    modifier = Modifier.weight(1f),
-                    aspectRatio = actionAspect, heightDp = actionHeight)
-                ActionTile(
-                    modifier = Modifier.weight(1f),
-                    icon = Icons.Default.FiberManualRecord,
-                    label = if (tripCount > 0) stringResource(R.string.action_recorder_trips, tripCount)
-                        else stringResource(R.string.action_recorder),
-                    active = recording,
-                    activeColor = if (useAccent) primary else AccentRed,
-                    onClick = { onNavigateToRecording() },
-                    aspectRatio = actionAspect, heightDp = actionHeight,
-                    menu = { dismiss ->
-                        val targetTripId = currentTripId ?: latestTripId
-                        DropdownMenuItem(
-                            text = { Text(stringResource(R.string.action_trip_backup_options)) },
-                            onClick = { dismiss(); onNavigateToSettings(4) }
-                        )
-                        androidx.compose.material3.HorizontalDivider(
-                            color = MaterialTheme.colorScheme.outline.copy(alpha = 0.2f)
-                        )
-                        DropdownMenuItem(
-                            text = {
-                                Text(
-                                    if (recording) stringResource(R.string.menu_view_current_trip)
-                                    else stringResource(R.string.menu_view_last_trip)
-                                )
-                            },
-                            enabled = targetTripId != null,
-                            onClick = {
-                                dismiss()
-                                targetTripId?.let { onNavigateToTripDetail(it) }
+                        // Per-key bridge: today's 6 defaults preserve
+                        // every quirk (active highlights, submenus,
+                        // lock-in-motion toast, trip-count label, etc.).
+                        // Any other key the rider drops in renders as a
+                        // catalog-driven generic tile that fires through
+                        // FlicManager via the standard onAction handler.
+                        when (key) {
+                            "HORN" -> ActionButton(
+                                Icons.Default.Campaign,
+                                stringResource(R.string.action_horn),
+                                enabled = connectionState == ConnectionState.CONNECTED,
+                                onClick = { viewModel.onHornPress() },
+                                modifier = Modifier.weight(1f),
+                                aspectRatio = actionAspect, heightDp = actionHeight
+                            )
+                            "LIGHT_TOGGLE" -> ActionTile(
+                                modifier = Modifier.weight(1f),
+                                icon = Icons.Default.FlashlightOn,
+                                label = stringResource(R.string.action_light),
+                                active = wheelData.lightOn,
+                                activeColor = if (useAccent) primary else AccentYellow,
+                                enabled = connectionState == ConnectionState.CONNECTED && !lightBusy,
+                                onClick = { viewModel.onLightToggle() },
+                                aspectRatio = actionAspect, heightDp = actionHeight,
+                                menu = { dismiss ->
+                                    DropdownMenuItem(
+                                        text = { Text(stringResource(R.string.menu_auto_lights)) },
+                                        onClick = { dismiss(); onNavigateToSettings(6) }
+                                    )
+                                }
+                            )
+                            "VOICE_ANNOUNCE" -> ActionTile(
+                                modifier = Modifier.weight(1f),
+                                icon = Icons.Default.RecordVoiceOver,
+                                label = stringResource(R.string.action_voice),
+                                onClick = { viewModel.onVoiceAnnounce() },
+                                aspectRatio = actionAspect, heightDp = actionHeight,
+                                menu = { dismiss ->
+                                    DropdownMenuItem(
+                                        text = { Text(stringResource(R.string.tab_voice)) },
+                                        onClick = { dismiss(); onNavigateToSettings(3) }
+                                    )
+                                    DropdownMenuItem(
+                                        text = { Text(stringResource(R.string.tab_alarms)) },
+                                        onClick = { dismiss(); onNavigateToSettings(5) }
+                                    )
+                                    androidx.compose.material3.HorizontalDivider(
+                                        color = MaterialTheme.colorScheme.outline.copy(alpha = 0.2f)
+                                    )
+                                    DropdownMenuItem(
+                                        text = {
+                                            Text(
+                                                if (periodicVoiceOn) stringResource(R.string.menu_voice_periodic_off)
+                                                else stringResource(R.string.menu_voice_periodic_on)
+                                            )
+                                        },
+                                        onClick = { dismiss(); viewModel.toggleVoicePeriodic() }
+                                    )
+                                }
+                            )
+                            "SAFETY_TOGGLE" -> ActionTile(
+                                modifier = Modifier.weight(1f),
+                                icon = Icons.Default.Shield,
+                                label = if (safetyActive) stringResource(R.string.action_legal_on)
+                                    else stringResource(R.string.action_legal_mode),
+                                active = safetyActive,
+                                activeColor = if (useAccent) primary else AccentOrange,
+                                enabled = connectionState == ConnectionState.CONNECTED,
+                                onClick = { viewModel.onSafetySpeedToggle() },
+                                aspectRatio = actionAspect, heightDp = actionHeight,
+                                menu = { dismiss ->
+                                    DropdownMenuItem(
+                                        text = { Text(stringResource(R.string.section_legal_mode_speed)) },
+                                        onClick = { dismiss(); onNavigateToSettings(2) }
+                                    )
+                                }
+                            )
+                            "LOCK_TOGGLE" -> ActionButton(
+                                if (locked) Icons.Default.Lock else Icons.Default.LockOpen,
+                                if (locked) stringResource(R.string.action_locked)
+                                    else stringResource(R.string.action_lock_wheel),
+                                active = locked,
+                                activeColor = if (useAccent) primary else AccentRed,
+                                enabled = connectionState == ConnectionState.CONNECTED && !lockBusy,
+                                onClick = {
+                                    if (lockBlockedBySpeed) {
+                                        val msg = toastContext.getString(R.string.lock_blocked_in_motion_toast)
+                                        snackbarScope.launch { snackbar.showSnackbar(msg) }
+                                    } else {
+                                        viewModel.onLockToggle()
+                                    }
+                                },
+                                modifier = Modifier.weight(1f),
+                                aspectRatio = actionAspect, heightDp = actionHeight
+                            )
+                            "RECORD_TOGGLE" -> ActionTile(
+                                modifier = Modifier.weight(1f),
+                                icon = Icons.Default.FiberManualRecord,
+                                label = if (tripCount > 0)
+                                    stringResource(R.string.action_recorder_trips, tripCount)
+                                    else stringResource(R.string.action_recorder),
+                                active = recording,
+                                activeColor = if (useAccent) primary else AccentRed,
+                                onClick = { onNavigateToRecording() },
+                                aspectRatio = actionAspect, heightDp = actionHeight,
+                                menu = { dismiss ->
+                                    val targetTripId = currentTripId ?: latestTripId
+                                    DropdownMenuItem(
+                                        text = { Text(stringResource(R.string.action_trip_backup_options)) },
+                                        onClick = { dismiss(); onNavigateToSettings(4) }
+                                    )
+                                    androidx.compose.material3.HorizontalDivider(
+                                        color = MaterialTheme.colorScheme.outline.copy(alpha = 0.2f)
+                                    )
+                                    DropdownMenuItem(
+                                        text = {
+                                            Text(
+                                                if (recording) stringResource(R.string.menu_view_current_trip)
+                                                else stringResource(R.string.menu_view_last_trip)
+                                            )
+                                        },
+                                        enabled = targetTripId != null,
+                                        onClick = {
+                                            dismiss()
+                                            targetTripId?.let { onNavigateToTripDetail(it) }
+                                        }
+                                    )
+                                    DropdownMenuItem(
+                                        text = {
+                                            Text(
+                                                if (recording) stringResource(R.string.menu_stop_recording)
+                                                else stringResource(R.string.menu_start_recording)
+                                            )
+                                        },
+                                        onClick = {
+                                            dismiss()
+                                            if (recording) viewModel.stopRecording()
+                                            else viewModel.startRecording()
+                                        }
+                                    )
+                                }
+                            )
+                            else -> when {
+                                // Action group instance (G:uuid). Reads
+                                // the rider's chosen name + icon from
+                                // dashboardActionGroupsJson. Tapping a
+                                // group should open a popover with its
+                                // sub-actions (matches the editor's
+                                // preview), but the popover machinery
+                                // lives in the settings module; for
+                                // now the tap is a no-op so the rider
+                                // still sees a recognisable tile.
+                                key.startsWith("G:") -> {
+                                    // Parse the group definition once per
+                                    // change to the groups JSON. Name +
+                                    // icon drive the tile face; the
+                                    // actions list drives the popover.
+                                    val parsedGroup = remember(dashboardActionGroupsJson, key) {
+                                        try {
+                                            val root = org.json.JSONObject(
+                                                dashboardActionGroupsJson.ifBlank { "{}" }
+                                            )
+                                            val node = root.optJSONObject(key)
+                                            val name = node?.optString("name", "") ?: ""
+                                            val iconKey = node?.optString("icon", "") ?: ""
+                                            val actionsArr = node?.optJSONArray("actions")
+                                            val actions = if (actionsArr != null) {
+                                                (0 until actionsArr.length()).mapNotNull {
+                                                    actionsArr.optString(it).takeIf { s -> s.isNotEmpty() }
+                                                }
+                                            } else emptyList()
+                                            Triple(name, iconKey, actions)
+                                        } catch (_: Exception) {
+                                            Triple("", "", emptyList<String>())
+                                        }
+                                    }
+                                    val (groupName, groupIcon, groupActions) = parsedGroup
+                                    val defaultGroupLabel = stringResource(
+                                        R.string.dashboard_group_default_name
+                                    )
+                                    // Capture the anchor tile's measured
+                                    // size so the popover can render its
+                                    // sub-action buttons at exactly the
+                                    // same width and height as the
+                                    // dashboard action row.
+                                    var anchorSizePx by remember {
+                                        mutableStateOf(androidx.compose.ui.unit.IntSize.Zero)
+                                    }
+                                    Box(
+                                        modifier = Modifier
+                                            .weight(1f)
+                                            .onGloballyPositioned { coords ->
+                                                anchorSizePx = coords.size
+                                            }
+                                    ) {
+                                        var popoverOpen by remember { mutableStateOf(false) }
+                                        ActionButton(
+                                            icon = if (groupIcon.isNotBlank())
+                                                com.eried.eucplanet.ui.settings.groupIconFor(groupIcon)
+                                            else Icons.Default.Campaign,
+                                            label = groupName.ifBlank { defaultGroupLabel },
+                                            enabled = true,
+                                            onClick = {
+                                                if (groupActions.isNotEmpty()) popoverOpen = true
+                                            },
+                                            modifier = Modifier.fillMaxWidth(),
+                                            aspectRatio = actionAspect, heightDp = actionHeight
+                                        )
+                                        if (popoverOpen) {
+                                            ActionGroupPopover(
+                                                actions = groupActions,
+                                                anchorSizePx = anchorSizePx,
+                                                onPick = { subKey ->
+                                                    viewModel.dispatchActionByName(subKey)
+                                                    popoverOpen = false
+                                                },
+                                                onDismiss = { popoverOpen = false }
+                                            )
+                                        }
+                                    }
+                                }
+                                else -> {
+                                    // Catalog-driven generic action.
+                                    // OPEN_* actions need explicit UI
+                                    // navigation (FlicManager has no
+                                    // navController); everything else
+                                    // routes through the shared dispatch.
+                                    val actionSpec = com.eried.eucplanet.data.model.ActionCatalog.byKey(key)
+                                    val labelText = actionSpec?.let { stringResource(it.labelRes) } ?: key
+                                    val tap: () -> Unit = when (key) {
+                                        "OPEN_ABOUT" -> ({ showAboutDialog = true })
+                                        "OPEN_NAVIGATION" -> onNavigateToNavigator
+                                        "OPEN_STUDIO" -> onNavigateToStudio
+                                        "OPEN_SERVICE" -> ({ onNavigateToSettings(7) })
+                                        "OPEN_TRIPS" -> onNavigateToRecording
+                                        else -> ({ viewModel.dispatchActionByName(key) })
+                                    }
+                                    ActionButton(
+                                        icon = actionSpec?.icon ?: Icons.Default.Campaign,
+                                        label = labelText,
+                                        enabled = connectionState == ConnectionState.CONNECTED || key.startsWith("OPEN_"),
+                                        onClick = tap,
+                                        modifier = Modifier.weight(1f),
+                                        aspectRatio = actionAspect, heightDp = actionHeight
+                                    )
+                                }
                             }
-                        )
-                        DropdownMenuItem(
-                            text = {
-                                Text(
-                                    if (recording) stringResource(R.string.menu_stop_recording)
-                                    else stringResource(R.string.menu_start_recording)
-                                )
-                            },
-                            onClick = {
-                                dismiss()
-                                if (recording) viewModel.stopRecording() else viewModel.startRecording()
-                            }
-                        )
+                        }
                     }
-                )
+                }
+                if (rowIdx == 0) Spacer(Modifier.height(8.dp))
             }
 
             Spacer(Modifier.height(12.dp))
 
             // Bottom info row: ODO + wheel model + firmware + version (tap for About)
-            var showAboutDialog by remember { mutableStateOf(false) }
-            var showDiagnosticsDialog by remember { mutableStateOf(false) }
+            // (showAboutDialog / showDiagnosticsDialog hoisted to the top of
+            // the screen so OPEN_ABOUT action bindings can trigger them.)
             val context = LocalContext.current
             val versionName = remember {
                 try {
@@ -1129,7 +1589,6 @@ fun DashboardScreen(
                             }
                     } catch (_: Exception) { "" }
                 }
-                var showDiagnosticsConfirm by remember { mutableStateOf(false) }
                 var logoPressed by remember { mutableStateOf(false) }
                 val logoAlpha by animateFloatAsState(
                     targetValue = if (logoPressed) 0.55f else 1f,
@@ -2152,6 +2611,172 @@ private fun ConnectionDot(state: ConnectionState) {
             .clip(CircleShape)
             .background(color)
     )
+}
+
+/**
+ * PopupPositionProvider that surfaces a popup just above the anchor
+ * with a slight overlap (top 25% of anchor sits under the popup) and a
+ * horizontal shift that depends on the anchor's column position:
+ *
+ *   - Left column (anchor in left third of window):
+ *       popup.left aligns to (anchor.left + 25% of anchor.width),
+ *       so the leftmost 25% of the anchor stays visible.
+ *   - Center column:
+ *       popup centers horizontally on the anchor.
+ *   - Right column (anchor in right third):
+ *       popup.right aligns to (anchor.right - 25% of anchor.width),
+ *       so the rightmost 25% of the anchor stays visible.
+ *
+ * The 25% slivers let the rider see where the popup came from while
+ * keeping the popup body close to the finger position.
+ */
+private class AboveAnchorPositionProvider : androidx.compose.ui.window.PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: androidx.compose.ui.unit.IntRect,
+        windowSize: androidx.compose.ui.unit.IntSize,
+        layoutDirection: androidx.compose.ui.unit.LayoutDirection,
+        popupContentSize: androidx.compose.ui.unit.IntSize
+    ): androidx.compose.ui.unit.IntOffset {
+        val overlapFraction = 0.25f
+        // Vertical overlap: pull the popup's bottom edge 25% of the
+        // anchor's height INTO the anchor, so the popup overlaps the
+        // top of the button.
+        val verticalOverlap = (anchorBounds.height * overlapFraction).toInt()
+        val y = (anchorBounds.top - popupContentSize.height + verticalOverlap)
+            .coerceAtLeast(8)
+
+        // Horizontal: figure out which third of the window the anchor
+        // sits in, then anchor the popup's left/center/right
+        // accordingly so the rider gets a 25% "sliver" visible on the
+        // far side from the screen center.
+        val anchorCenterX = anchorBounds.left + anchorBounds.width / 2
+        val leftThird = windowSize.width / 3
+        val rightThird = windowSize.width * 2 / 3
+        val edgeSliver = (anchorBounds.width * overlapFraction).toInt()
+        val rawX = when {
+            anchorCenterX < leftThird ->
+                anchorBounds.left + edgeSliver
+            anchorCenterX > rightThird ->
+                anchorBounds.right - edgeSliver - popupContentSize.width
+            else ->
+                anchorBounds.left + (anchorBounds.width - popupContentSize.width) / 2
+        }
+        val maxX = (windowSize.width - popupContentSize.width - 8).coerceAtLeast(8)
+        val clampedX = rawX.coerceIn(8, maxX)
+        return androidx.compose.ui.unit.IntOffset(clampedX, y)
+    }
+}
+
+/**
+ * Floating popover that renders an action group's sub-actions as compact
+ * tile-shaped buttons, surfacing ABOVE the tapped tile so the popup never
+ * lands under the rider's finger. Layout adapts to the number of actions:
+ *   - 1 action  → single tile
+ *   - 2 actions → one row of 2
+ *   - 3 actions → one row of 3
+ *   - 4 actions → 2x2 grid
+ *
+ * Tap any tile → [onPick] fires (which dispatches the sub-action) and
+ * the parent closes the popover. Tapping outside dismisses without
+ * firing anything.
+ */
+@OptIn(androidx.compose.animation.ExperimentalAnimationApi::class)
+@Composable
+private fun ActionGroupPopover(
+    actions: List<String>,
+    anchorSizePx: androidx.compose.ui.unit.IntSize,
+    onPick: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val density = androidx.compose.ui.platform.LocalDensity.current
+    // Convert the anchor tile's measured size to dp so each sub-action
+    // button can render at the EXACT same width and height. Fallback to
+    // sensible defaults if the anchor hasn't measured yet (first frame).
+    val buttonWidthDp = with(density) {
+        if (anchorSizePx.width > 0) anchorSizePx.width.toDp() else 104.dp
+    }
+    val buttonHeightDp = with(density) {
+        if (anchorSizePx.height > 0) anchorSizePx.height.toDp() else 104.dp
+    }
+
+    // Animation: scale-in + fade-in from the bottom-center so the popup
+    // visibly pops out of the button the rider tapped. Trigger by
+    // flipping `visible` to true on first composition.
+    var visible by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { visible = true }
+
+    androidx.compose.ui.window.Popup(
+        popupPositionProvider = AboveAnchorPositionProvider(),
+        onDismissRequest = onDismiss,
+        properties = androidx.compose.ui.window.PopupProperties(
+            focusable = true,
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true
+        )
+    ) {
+        androidx.compose.animation.AnimatedVisibility(
+            visible = visible,
+            enter = androidx.compose.animation.scaleIn(
+                initialScale = 0.85f,
+                animationSpec = androidx.compose.animation.core.tween(180),
+                // Pivot the scale-in from the bottom of the popup so it
+                // visibly "grows out" of the action button below it.
+                transformOrigin = androidx.compose.ui.graphics.TransformOrigin(0.5f, 1.0f)
+            ) + androidx.compose.animation.fadeIn(
+                animationSpec = androidx.compose.animation.core.tween(150)
+            ),
+            exit = androidx.compose.animation.fadeOut(
+                animationSpec = androidx.compose.animation.core.tween(100)
+            )
+        ) {
+            // ElevatedCard draws a native Android drop shadow at the
+            // requested elevation (handled by the platform Renderer,
+            // not a custom blur), which is what the rider asked for —
+            // crisp and consistent with other M3 surfaces.
+            androidx.compose.material3.ElevatedCard(
+                shape = RoundedCornerShape(14.dp),
+                colors = androidx.compose.material3.CardDefaults.elevatedCardColors(
+                    containerColor = MaterialTheme.colorScheme.surface
+                ),
+                elevation = androidx.compose.material3.CardDefaults.elevatedCardElevation(
+                    defaultElevation = 8.dp
+                )
+            ) {
+                Column(modifier = Modifier.padding(8.dp)) {
+                    val takeFour = actions.take(4)
+                    val rows: List<List<String>> = when (takeFour.size) {
+                        4 -> listOf(takeFour.subList(0, 2), takeFour.subList(2, 4))
+                        else -> listOf(takeFour)
+                    }
+                    rows.forEachIndexed { rowIdx, rowActions ->
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            rowActions.forEach { subKey ->
+                                val subSpec = com.eried.eucplanet.data.model.ActionCatalog.byKey(subKey)
+                                val subLabel = subSpec?.let { stringResource(it.labelRes) } ?: subKey
+                                // Each tile gets the anchor's exact
+                                // pixel-perfect width and height so it
+                                // looks identical to the dashboard
+                                // action button row.
+                                ActionButton(
+                                    icon = subSpec?.icon ?: Icons.Default.Campaign,
+                                    label = subLabel,
+                                    onClick = { onPick(subKey) },
+                                    modifier = Modifier
+                                        .width(buttonWidthDp)
+                                        .height(buttonHeightDp),
+                                    aspectRatio = null,
+                                    heightDp = null
+                                )
+                            }
+                        }
+                        if (rowIdx < rows.lastIndex) Spacer(Modifier.height(8.dp))
+                    }
+                }
+            }
+        }
+    }
 }
 
 @OptIn(ExperimentalFoundationApi::class)

--- a/app/src/main/java/com/eried/eucplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/eried/eucplanet/ui/dashboard/DashboardViewModel.kt
@@ -140,6 +140,23 @@ class DashboardViewModel @Inject constructor(
         .map { it != null }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
+    /** Raw location for catalog metrics (altitude / accuracy / GPS speed / heading). */
+    val currentLocation = tripRepository.currentLocation
+
+    /**
+     * Phone battery percentage (0–100). Polled from the system service
+     * via a 30-second tick, since it doesn't change fast enough to
+     * justify a registered receiver here. Returns -1 when unavailable.
+     */
+    val phoneBatteryPercent: StateFlow<Int> = kotlinx.coroutines.flow.flow {
+        while (true) {
+            val bm = context.getSystemService(Context.BATTERY_SERVICE) as? android.os.BatteryManager
+            val pct = bm?.getIntProperty(android.os.BatteryManager.BATTERY_PROPERTY_CAPACITY) ?: -1
+            emit(pct)
+            kotlinx.coroutines.delay(30_000L)
+        }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), -1)
+
     private val _locationPermissionGranted = kotlinx.coroutines.flow.MutableStateFlow(hasLocationPermission())
     val locationPermissionGranted: StateFlow<Boolean> = _locationPermissionGranted
 
@@ -272,6 +289,41 @@ class DashboardViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), "MODEL")
 
     val firmwareVersion: StateFlow<String?> = wheelRepository.firmwareVersion
+
+    // ---- Customizable dashboard layout (Phase 2B+) ----
+    //
+    // The editor in Settings writes these fields; the live dashboard
+    // reads them here to drive which tile renders in each slot, with
+    // what per-slot stats (sparkline on/off, corner readouts) and
+    // dynamic-instance state (composites, custom tiles, action groups).
+    //
+    // Order strings sanitize against [com.eried.eucplanet.data.model.MetricCatalog]
+    // / ActionCatalog upstream; here they're just raw strings until the
+    // dashboard composable parses them.
+    val dashboardMetricOrder: StateFlow<String> = settingsRepository.settings
+        .map { it.dashboardMetricOrder }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), "")
+    val dashboardMetricStats: StateFlow<String> = settingsRepository.settings
+        .map { it.dashboardMetricStats }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), "{}")
+    val dashboardMetricsColumns: StateFlow<Int> = settingsRepository.settings
+        .map { it.dashboardMetricsColumns }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 2)
+    val dashboardCompositeMetrics: StateFlow<String> = settingsRepository.settings
+        .map { it.dashboardCompositeMetrics }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), "{}")
+    val dashboardCustomTiles: StateFlow<String> = settingsRepository.settings
+        .map { it.dashboardCustomTiles }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), "{}")
+    val dashboardActionOrder: StateFlow<String> = settingsRepository.settings
+        .map { it.dashboardActionOrder }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), "")
+    val dashboardActionGroups: StateFlow<String> = settingsRepository.settings
+        .map { it.dashboardActionGroups }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), "{}")
+
+    /** Fires an action by its catalog key via FlicManager — shared dispatch with Flic / volume / watch. */
+    fun dispatchActionByName(key: String) = flicManager.dispatchActionByName(key)
 
     val fullHistory: StateFlow<FullMetricHistory> = wheelRepository.fullHistory
 

--- a/app/src/main/java/com/eried/eucplanet/ui/dashboard/LiveMetricTile.kt
+++ b/app/src/main/java/com/eried/eucplanet/ui/dashboard/LiveMetricTile.kt
@@ -1,0 +1,243 @@
+package com.eried.eucplanet.ui.dashboard
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.eried.eucplanet.data.model.SparklineStyle
+
+/**
+ * Live dashboard metric tile. One renderer for every metric, driven by
+ * the per-metric [SparklineStyle] in [com.eried.eucplanet.data.model.MetricCatalog].
+ *
+ * Visual contract: when the rider hasn't customized the layout, the
+ * default tiles (BATTERY / TEMPERATURE / VOLTAGE / CURRENT / LOAD / TRIP)
+ * render exactly like the old hardcoded StatCard. Riders who customize
+ * to a less-common metric get the same overall shape (label on top, big
+ * centered value, sparkline behind) with a style that fits the metric's
+ * shape (line for slow-moving, area for accumulating, bipolar-area for
+ * signed values that swing through zero).
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun LiveMetricTile(
+    label: String,
+    value: String,
+    accent: Color,
+    sparkData: List<Float>,
+    sparkStyle: SparklineStyle,
+    /** Whether the rider has the sparkline background enabled for this slot. */
+    sparklineEnabled: Boolean,
+    modifier: Modifier = Modifier,
+    /** Baseline for [SparklineStyle.AREA_BIPOLAR]; ignored for other styles. */
+    bipolarBaseline: Float = 0f,
+    /** Negative-lobe colour for [SparklineStyle.AREA_BIPOLAR]; defaults to a darker [accent]. */
+    bipolarNegativeAccent: Color? = null,
+    onClick: (() -> Unit)? = null,
+    onLongClick: (() -> Unit)? = null
+) {
+    val clickModifier = when {
+        onClick != null || onLongClick != null -> Modifier.combinedClickable(
+            onClick = { onClick?.invoke() },
+            onLongClick = onLongClick
+        )
+        else -> Modifier
+    }
+    // No data → no chart. The default 5 metrics (BATTERY, TEMPERATURE,
+    // VOLTAGE, CURRENT, LOAD) get their own bespoke disconnected demos
+    // from DashboardScreen so cold-boot still has personality; every
+    // other catalog metric renders empty until real samples arrive.
+    // An empty tile honestly signals "no data yet" — better than a
+    // synthetic curve that riders could mistake for telemetry.
+    val effectiveSparkData = sparkData
+    Box(
+        modifier = modifier
+            .heightIn(min = 61.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .then(clickModifier),
+        contentAlignment = Alignment.Center
+    ) {
+        // Sparkline canvas — drawn whenever the rider has it enabled
+        // AND the metric style isn't NONE. effectiveSparkData supplies
+        // a decorative sine when real samples haven't arrived yet so
+        // every catalog tile looks alive on cold boot.
+        if (sparklineEnabled && sparkStyle != SparklineStyle.NONE && effectiveSparkData.size >= 2) {
+            Canvas(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .matchParentSize()
+            ) {
+                val padding = size.height * 0.15f
+                val drawHeight = size.height - padding * 2
+                val stepX = size.width / (effectiveSparkData.size - 1).toFloat()
+                val min = effectiveSparkData.min()
+                val max = effectiveSparkData.max()
+                // Bipolar style anchors the visible range to span the
+                // baseline, so the chart honestly shows "this much
+                // above zero" vs "this much below zero" rather than
+                // normalising the whole range to fill the box.
+                val effectiveMin: Float
+                val effectiveMax: Float
+                if (sparkStyle == SparklineStyle.AREA_BIPOLAR) {
+                    effectiveMin = kotlin.math.min(min, bipolarBaseline)
+                    effectiveMax = kotlin.math.max(max, bipolarBaseline)
+                } else {
+                    effectiveMin = min
+                    effectiveMax = max
+                }
+                val range = (effectiveMax - effectiveMin).coerceAtLeast(0.1f)
+
+                fun yFor(v: Float): Float {
+                    return padding + drawHeight - ((v - effectiveMin) / range) * drawHeight
+                }
+
+                when (sparkStyle) {
+                    SparklineStyle.LINE -> {
+                        val path = Path()
+                        effectiveSparkData.forEachIndexed { idx, v ->
+                            val x = idx * stepX
+                            val y = yFor(v)
+                            if (idx == 0) path.moveTo(x, y) else path.lineTo(x, y)
+                        }
+                        drawPath(path, color = accent.copy(alpha = 0.4f), style = Stroke(width = 2.5f))
+                    }
+
+                    SparklineStyle.SMOOTH_LINE -> {
+                        // Catmull-Rom-ish smoothing via quadratic
+                        // beziers between midpoints. Cheaper than a
+                        // true Catmull-Rom and visually indistinguishable
+                        // at 15-sample sparkline scale.
+                        val path = Path()
+                        if (effectiveSparkData.isNotEmpty()) {
+                            var prevX = 0f
+                            var prevY = yFor(effectiveSparkData[0])
+                            path.moveTo(prevX, prevY)
+                            for (i in 1 until effectiveSparkData.size) {
+                                val curX = i * stepX
+                                val curY = yFor(effectiveSparkData[i])
+                                val midX = (prevX + curX) / 2f
+                                val midY = (prevY + curY) / 2f
+                                path.quadraticTo(prevX, prevY, midX, midY)
+                                prevX = curX; prevY = curY
+                            }
+                            path.lineTo(prevX, prevY)
+                        }
+                        drawPath(path, color = accent.copy(alpha = 0.4f), style = Stroke(width = 2.5f))
+                    }
+
+                    SparklineStyle.AREA -> {
+                        // Today's default look: stroke + faint fill
+                        // underneath. Keeps the default tiles visually
+                        // identical to the old hardcoded StatCard.
+                        val linePath = Path()
+                        effectiveSparkData.forEachIndexed { idx, v ->
+                            val x = idx * stepX
+                            val y = yFor(v)
+                            if (idx == 0) linePath.moveTo(x, y) else linePath.lineTo(x, y)
+                        }
+                        val fillPath = Path()
+                        fillPath.addPath(linePath)
+                        fillPath.lineTo(size.width, size.height)
+                        fillPath.lineTo(0f, size.height)
+                        fillPath.close()
+                        drawPath(fillPath, color = accent.copy(alpha = 0.08f))
+                        drawPath(linePath, color = accent.copy(alpha = 0.4f), style = Stroke(width = 2.5f))
+                    }
+
+                    SparklineStyle.AREA_BIPOLAR -> {
+                        val baselineY = yFor(bipolarBaseline)
+                        val negAccent = bipolarNegativeAccent ?: accent
+                        // Positive lobe — fill between the line and the
+                        // baseline for samples that sit above baseline.
+                        val posFill = Path()
+                        posFill.moveTo(0f, baselineY)
+                        effectiveSparkData.forEachIndexed { idx, v ->
+                            val x = idx * stepX
+                            val y = yFor(v)
+                            // Cap below the baseline so the negative
+                            // lobe's fill stays in the other path.
+                            posFill.lineTo(x, kotlin.math.min(y, baselineY))
+                        }
+                        posFill.lineTo(size.width, baselineY)
+                        posFill.close()
+                        drawPath(posFill, color = accent.copy(alpha = 0.18f))
+
+                        // Negative lobe — mirror logic for samples below baseline.
+                        val negFill = Path()
+                        negFill.moveTo(0f, baselineY)
+                        effectiveSparkData.forEachIndexed { idx, v ->
+                            val x = idx * stepX
+                            val y = yFor(v)
+                            negFill.lineTo(x, kotlin.math.max(y, baselineY))
+                        }
+                        negFill.lineTo(size.width, baselineY)
+                        negFill.close()
+                        drawPath(negFill, color = negAccent.copy(alpha = 0.18f))
+
+                        // Stroke the polyline on top of both fills so
+                        // the rider sees the actual curve clearly.
+                        val linePath = Path()
+                        effectiveSparkData.forEachIndexed { idx, v ->
+                            val x = idx * stepX
+                            val y = yFor(v)
+                            if (idx == 0) linePath.moveTo(x, y) else linePath.lineTo(x, y)
+                        }
+                        drawPath(linePath, color = accent.copy(alpha = 0.5f), style = Stroke(width = 2.5f))
+                    }
+
+                    SparklineStyle.NONE -> Unit
+                }
+            }
+        }
+
+        // Text content centered. Padding gives the sparkline room to
+        // breathe behind the value text without overlapping it visually.
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 10.dp, horizontal = 12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                // Uppercase so labels read consistently regardless of
+                // whether the source is a stat_* string (already caps)
+                // or a metric_chip_* string (proper case in the editor).
+                // .uppercase() is idempotent on already-uppercase strings.
+                label.uppercase(),
+                fontSize = 10.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontWeight = FontWeight.Medium,
+                letterSpacing = 0.5.sp
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                value,
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold,
+                color = accent,
+                maxLines = 1
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/eried/eucplanet/ui/dashboard/MetricDetailScreen.kt
+++ b/app/src/main/java/com/eried/eucplanet/ui/dashboard/MetricDetailScreen.kt
@@ -6,8 +6,10 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -21,22 +23,29 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Restore
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -59,77 +68,110 @@ import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.eried.eucplanet.util.GraphBounds
-import com.eried.eucplanet.util.GraphScale
 import com.eried.eucplanet.R
+import com.eried.eucplanet.data.model.WheelData
 import com.eried.eucplanet.data.repository.MetricSample
 import com.eried.eucplanet.ui.theme.AccentBlue
 import com.eried.eucplanet.ui.theme.AccentGreen
 import com.eried.eucplanet.ui.theme.AccentOrange
 import com.eried.eucplanet.ui.theme.AccentRed
+import com.eried.eucplanet.util.GraphBounds
+import com.eried.eucplanet.util.GraphScale
 
+/**
+ * Legacy enum kept for the 6 buffered metrics whose detail rendering has
+ * bespoke graph bounds + unit conversion. The unified [MetricDetailScreen]
+ * derives the rest of its metadata from [com.eried.eucplanet.data.model.MetricCatalog].
+ */
 enum class MetricType(val titleRes: Int, val unit: String, val color: Color) {
     BATTERY(R.string.metric_battery, "%", AccentGreen),
-    TEMPERATURE(R.string.metric_temperature, "\u00B0C", AccentOrange),
+    TEMPERATURE(R.string.metric_temperature, "°C", AccentOrange),
     VOLTAGE(R.string.metric_voltage, "V", AccentBlue),
     CURRENT(R.string.metric_current, "A", AccentBlue),
     LOAD(R.string.metric_load, "%", AccentOrange),
     SPEED(R.string.metric_speed, "km/h", AccentGreen)
 }
 
+/**
+ * Current raw value for any catalog metric key that doesn't have a
+ * dedicated [MetricType] entry. Maps to the same WheelData fields the
+ * dashboard's `displayValueFor` uses, returning 0 for keys the dashboard
+ * doesn't yet source (GPS / phone-battery / derived aggregates).
+ */
+private fun rawCurrentValueFor(key: String, w: WheelData): Float = when (key) {
+    "POWER", "BATTERY_POWER" -> w.batteryPower.toFloat()
+    "MOTOR_POWER" -> w.motorPower.toFloat()
+    "ODOMETER" -> w.totalDistance
+    "BATTERY_1" -> w.battery1Percent
+    "BATTERY_2" -> w.battery2Percent
+    "PITCH" -> w.pitchAngle
+    "ROLL" -> w.rollAngle
+    "G_FORCE" -> w.gForce
+    "LATERAL_G" -> w.accelX
+    "FORWARD_G" -> w.accelY
+    "TORQUE" -> w.torque
+    "DYN_SPEED_LIMIT" -> w.dynamicSpeedLimit
+    "DYN_CURRENT_LIMIT" -> w.dynamicCurrentLimit
+    "MOTOR_TEMP" -> w.temperatures.getOrNull(0) ?: 0f
+    "CONTROLLER_TEMP" -> w.temperatures.getOrNull(1) ?: 0f
+    "BATTERY_TEMP" -> w.temperatures.getOrNull(2) ?: 0f
+    else -> 0f
+}
+
+/**
+ * Unified full-screen metric detail. Renders any list of metric keys
+ * as tabs across the top with the selected tab's chart + stats below.
+ *
+ * A single-metric tap from the dashboard produces a 1-tab list — same
+ * layout as before, just with an inert tab strip. A composite-tile tap
+ * produces an N-tab list (one per sub-metric). One control, one route,
+ * one mental model.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MetricDetailScreen(
-    metricType: MetricType,
+    metricKeys: List<String>,
     onBack: () -> Unit,
+    initialTabIndex: Int = 0,
     viewModel: MetricDetailViewModel = hiltViewModel()
 ) {
+    val keys = remember(metricKeys) { metricKeys.filter { it.isNotBlank() } }
+    if (keys.isEmpty()) {
+        LaunchedEffect(Unit) { onBack() }
+        return
+    }
+    // Seed selectedIdx from the nav arg so a side-tap on a composite
+    // dashboard tile pre-selects the matching tab without changing the
+    // visible order of the tab strip.
+    var selectedIdx by remember(metricKeys) {
+        mutableIntStateOf(initialTabIndex.coerceIn(0, keys.lastIndex))
+    }
+    val safeIdx = selectedIdx.coerceIn(0, keys.lastIndex)
+    val activeKey = keys[safeIdx]
+
     val fullHistory by viewModel.fullHistory.collectAsState()
     val wheelData by viewModel.wheelData.collectAsState()
     val speedUnit by viewModel.speedUnit.collectAsState()
     val tempUnit by viewModel.tempUnit.collectAsState()
 
-    val rawSamples: List<MetricSample> = when (metricType) {
-        MetricType.BATTERY -> fullHistory.battery
-        MetricType.TEMPERATURE -> fullHistory.temperature
-        MetricType.VOLTAGE -> fullHistory.voltage
-        MetricType.CURRENT -> fullHistory.current
-        MetricType.LOAD -> fullHistory.load
-        MetricType.SPEED -> fullHistory.speed
-    }
+    // Long-press Reset → confirmation dialog → wipe ALL history buffers.
+    var showResetAllConfirm by remember { mutableStateOf(false) }
 
-    fun convert(v: Float): Float = when (metricType) {
-        MetricType.TEMPERATURE -> com.eried.eucplanet.util.Units.temperature(v, tempUnit)
-        MetricType.SPEED -> com.eried.eucplanet.util.Units.speed(v, speedUnit)
-        else -> v
-    }
-
-    val samples: List<MetricSample> = if (metricType == MetricType.TEMPERATURE || metricType == MetricType.SPEED) {
-        rawSamples.map { MetricSample(it.timestampMs, convert(it.value)) }
-    } else rawSamples
-
-    val unitLabel = when (metricType) {
-        MetricType.TEMPERATURE -> com.eried.eucplanet.util.Units.tempUnit(tempUnit)
-        MetricType.SPEED -> com.eried.eucplanet.util.Units.speedUnit(androidx.compose.ui.platform.LocalContext.current, speedUnit)
-        else -> metricType.unit
-    }
-
-    val currentValue = convert(when (metricType) {
-        MetricType.BATTERY -> wheelData.batteryPercent.toFloat()
-        MetricType.TEMPERATURE -> wheelData.maxTemperature
-        MetricType.VOLTAGE -> wheelData.voltage
-        MetricType.CURRENT -> wheelData.current
-        MetricType.LOAD -> kotlin.math.abs(wheelData.pwm)
-        MetricType.SPEED -> kotlin.math.abs(wheelData.speed)
-    })
+    // Title is the generic "History" — the active tab tells the rider
+    // which metric they're inspecting, so re-stating the metric name in
+    // the AppBar is redundant.
+    val titleLabel = stringResource(R.string.metric_detail_title)
 
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.metric_detail_title, stringResource(metricType.titleRes))) },
+                title = { Text(titleLabel) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.action_back))
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back)
+                        )
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
@@ -142,87 +184,398 @@ fun MetricDetailScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
-                .padding(16.dp)
                 .verticalScroll(rememberScrollState())
         ) {
-            // Current value large
-            Text(
-                "${"%.1f".format(currentValue)} ${unitLabel}",
-                fontSize = 48.sp,
-                fontWeight = FontWeight.Bold,
-                color = metricType.color
-            )
-
-            Spacer(Modifier.height(8.dp))
-
-            if (samples.size >= 2) {
-                // History is already time-windowed to 5 min in WheelRepository,
-                // so the slice here is just defensive, no need to cap by count.
-                val windowSamples = samples
-                val values = windowSamples.map { it.value }
-                val min = values.min()
-                val max = values.max()
-                val avg = values.average().toFloat()
-                val duration = (windowSamples.last().timestampMs - windowSamples.first().timestampMs) / 1000
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    StatSummary(stringResource(R.string.metric_min), "%.1f".format(min), unitLabel)
-                    StatSummary(stringResource(R.string.metric_avg), "%.1f".format(avg), unitLabel)
-                    StatSummary(stringResource(R.string.metric_max), "%.1f".format(max), unitLabel)
-                    StatSummary(stringResource(R.string.metric_time), formatDuration(duration), "")
+            // Tab strip — always rendered for consistency, even with a
+            // single metric (1 tab). Rider sees the same control whether
+            // they tapped a standalone tile or a composite.
+            PrimaryTabRow(
+                selectedTabIndex = safeIdx,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                keys.forEachIndexed { idx, key ->
+                    val spec = com.eried.eucplanet.data.model.MetricCatalog.byKey(key)
+                    val label = spec?.let { stringResource(it.labelRes) } ?: key
+                    Tab(
+                        selected = safeIdx == idx,
+                        onClick = { selectedIdx = idx },
+                        text = {
+                            Text(
+                                label.uppercase(),
+                                fontSize = 11.sp,
+                                fontWeight = FontWeight.Medium,
+                                maxLines = 1
+                            )
+                        }
+                    )
                 }
-
-                Spacer(Modifier.height(16.dp))
-
-                val boundsFor: (Float, Float) -> GraphBounds = when (metricType) {
-                    MetricType.BATTERY -> { _, _ -> GraphScale.fixed(0f, 100f) }
-                    MetricType.TEMPERATURE -> { min, max -> GraphScale.absolute(min, max, 5f) }
-                    MetricType.LOAD -> { min, max -> GraphScale.absolute(min, max, 5f) }
-                    MetricType.CURRENT -> { min, max -> GraphScale.absolute(min, max, 1f) }
-                    MetricType.VOLTAGE -> { min, max -> GraphScale.pad(min, max, GraphScale.SPAN_VOLTAGE) }
-                    MetricType.SPEED -> { min, max ->
-                        GraphScale.pad(min, max, when (speedUnit) {
-                            "mph" -> GraphScale.SPAN_SPEED_MPH
-                            "ms" -> GraphScale.SPAN_SPEED_MS
-                            else -> GraphScale.SPAN_SPEED_KMH
-                        })
-                    }
-                }
-
-                MetricGraph(
-                    samples = windowSamples,
-                    color = metricType.color,
-                    boundsFor = boundsFor,
-                    unitLabel = unitLabel,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(280.dp)
-                )
-            } else {
-                Spacer(Modifier.height(16.dp))
-                EmptyGraph(
-                    color = metricType.color,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(200.dp)
-                )
             }
 
-            Spacer(Modifier.height(16.dp))
+            Column(modifier = Modifier.padding(16.dp)) {
+                MetricDetailBody(
+                    key = activeKey,
+                    fullHistory = fullHistory,
+                    wheelData = wheelData,
+                    speedUnit = speedUnit,
+                    tempUnit = tempUnit
+                )
+
+                Spacer(Modifier.height(16.dp))
+
+                // Reset footer. Tap = reset active tab's metric history;
+                // long-press = open confirm dialog, then wipe ALL buffers.
+                // The old "Reset all" button is gone — collapsed into a
+                // long-press gesture so the toolbar reads cleaner and the
+                // destructive action is harder to fire accidentally.
+                ResetWithLongPressConfirm(
+                    onResetActive = { viewModel.resetHistory(activeKey) },
+                    onRequestResetAll = { showResetAllConfirm = true }
+                )
+
+                Spacer(Modifier.height(8.dp))
+            }
+
+            if (showResetAllConfirm) {
+                AlertDialog(
+                    onDismissRequest = { showResetAllConfirm = false },
+                    title = { Text(stringResource(R.string.metric_detail_reset_all_confirm_title)) },
+                    text = { Text(stringResource(R.string.metric_detail_reset_all_confirm_body)) },
+                    confirmButton = {
+                        androidx.compose.material3.TextButton(onClick = {
+                            viewModel.resetAllHistory()
+                            showResetAllConfirm = false
+                        }) {
+                            Text(stringResource(R.string.metric_detail_reset_all))
+                        }
+                    },
+                    dismissButton = {
+                        androidx.compose.material3.TextButton(onClick = { showResetAllConfirm = false }) {
+                            Text(stringResource(R.string.action_cancel))
+                        }
+                    }
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun ResetWithLongPressConfirm(
+    onResetActive: () -> Unit,
+    onRequestResetAll: () -> Unit
+) {
+    // Wrap so the button sits on the left edge instead of stretching.
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.Start
+    ) {
+        Row(
+            modifier = Modifier
+                .clip(RoundedCornerShape(20.dp))
+                .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f))
+                .combinedClickable(
+                    onClick = onResetActive,
+                    onLongClick = onRequestResetAll
+                )
+                .padding(horizontal = 14.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                Icons.Filled.Restore,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+                tint = MaterialTheme.colorScheme.primary
+            )
+            Spacer(Modifier.width(6.dp))
+            Text(
+                stringResource(R.string.metric_detail_reset),
+                color = MaterialTheme.colorScheme.primary,
+                fontWeight = FontWeight.Medium,
+                fontSize = 13.sp
+            )
         }
     }
 }
 
 @Composable
-private fun StatSummary(label: String, value: String, unit: String) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Text(label, fontSize = 10.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
-            fontWeight = FontWeight.Medium, letterSpacing = 0.5.sp)
-        Text("$value$unit", fontSize = 16.sp, fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onSurface)
+private fun MetricDetailBody(
+    key: String,
+    fullHistory: com.eried.eucplanet.data.repository.FullMetricHistory,
+    wheelData: WheelData,
+    speedUnit: String,
+    tempUnit: String
+) {
+    val legacyType: MetricType? = runCatching { MetricType.valueOf(key) }.getOrNull()
+    val catalogSpec = com.eried.eucplanet.data.model.MetricCatalog.byKey(key)
+
+    val rawSamples: List<MetricSample> = when (legacyType) {
+        MetricType.BATTERY -> fullHistory.battery
+        MetricType.TEMPERATURE -> fullHistory.temperature
+        MetricType.VOLTAGE -> fullHistory.voltage
+        MetricType.CURRENT -> fullHistory.current
+        MetricType.LOAD -> fullHistory.load
+        MetricType.SPEED -> fullHistory.speed
+        null -> emptyList()
+    }
+
+    fun convert(v: Float): Float = when (legacyType) {
+        MetricType.TEMPERATURE -> com.eried.eucplanet.util.Units.temperature(v, tempUnit)
+        MetricType.SPEED -> com.eried.eucplanet.util.Units.speed(v, speedUnit)
+        else -> v
+    }
+
+    val samples: List<MetricSample> =
+        if (legacyType == MetricType.TEMPERATURE || legacyType == MetricType.SPEED) {
+            rawSamples.map { MetricSample(it.timestampMs, convert(it.value)) }
+        } else rawSamples
+
+    val unitLabel = when (legacyType) {
+        MetricType.TEMPERATURE -> com.eried.eucplanet.util.Units.tempUnit(tempUnit)
+        MetricType.SPEED -> com.eried.eucplanet.util.Units.speedUnit(
+            androidx.compose.ui.platform.LocalContext.current, speedUnit
+        )
+        null -> ""
+        else -> legacyType.unit
+    }
+
+    val currentValue = when (legacyType) {
+        MetricType.BATTERY -> convert(wheelData.batteryPercent.toFloat())
+        MetricType.TEMPERATURE -> convert(wheelData.maxTemperature)
+        MetricType.VOLTAGE -> convert(wheelData.voltage)
+        MetricType.CURRENT -> convert(wheelData.current)
+        MetricType.LOAD -> convert(kotlin.math.abs(wheelData.pwm))
+        MetricType.SPEED -> convert(kotlin.math.abs(wheelData.speed))
+        null -> rawCurrentValueFor(key, wheelData)
+    }
+
+    val accentColor = legacyType?.color ?: catalogSpec?.accent ?: AccentBlue
+
+    Text(
+        "${"%.1f".format(currentValue)} $unitLabel",
+        fontSize = 48.sp,
+        fontWeight = FontWeight.Bold,
+        color = accentColor,
+        textAlign = androidx.compose.ui.text.style.TextAlign.End,
+        modifier = Modifier.fillMaxWidth()
+    )
+
+    Spacer(Modifier.height(8.dp))
+
+    // Stats region — always visible, two rows so the rider sees a
+    // consistent dashboard regardless of whether the buffer is full.
+    // Row 1 = central tendency + extremes; row 2 = percentiles + count
+    // + window time. Cells render `--` when the buffer is empty so the
+    // layout stays stable.
+    val values = samples.map { it.value }
+    val hasBuffer = values.size >= 2
+    val placeholderStat = "--"
+    val minStr = if (hasBuffer) "%.1f".format(values.min()) else placeholderStat
+    val maxStr = if (hasBuffer) "%.1f".format(values.max()) else placeholderStat
+    val avgStr = if (hasBuffer) "%.1f".format(values.average()) else placeholderStat
+    val medStr = if (hasBuffer) "%.1f".format(
+        com.eried.eucplanet.ui.settings.computeDashboardStatValue(
+            com.eried.eucplanet.ui.settings.DashboardStat.MEDIAN, samples, currentValue
+        ) ?: 0f
+    ) else placeholderStat
+    val p95Str = if (hasBuffer) "%.1f".format(
+        com.eried.eucplanet.ui.settings.computeDashboardStatValue(
+            com.eried.eucplanet.ui.settings.DashboardStat.P95, samples, currentValue
+        ) ?: 0f
+    ) else placeholderStat
+    val countStr = if (samples.isNotEmpty()) values.size.toString() else placeholderStat
+    val durationStr = if (hasBuffer) {
+        formatDuration((samples.last().timestampMs - samples.first().timestampMs) / 1000)
+    } else placeholderStat
+
+    // Primary stats: three accent-tinted pills — Min / Avg / Max.
+    // These are the headline numbers a rider cares about most.
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        StatPill(
+            label = stringResource(R.string.metric_min),
+            value = minStr,
+            unit = unitLabel,
+            accent = accentColor,
+            modifier = Modifier.weight(1f)
+        )
+        StatPill(
+            label = stringResource(R.string.metric_avg),
+            value = avgStr,
+            unit = unitLabel,
+            accent = accentColor,
+            modifier = Modifier.weight(1f)
+        )
+        StatPill(
+            label = stringResource(R.string.metric_max),
+            value = maxStr,
+            unit = unitLabel,
+            accent = accentColor,
+            modifier = Modifier.weight(1f)
+        )
+    }
+
+    Spacer(Modifier.height(10.dp))
+
+    // Secondary stats: a single thin row with the supporting numbers.
+    // Bullet-separated inline text reads as a footer, not a grid, so
+    // it doesn't compete with the three pills above for attention.
+    StatSecondaryRow(
+        median = medStr,
+        p95 = p95Str,
+        count = countStr,
+        duration = durationStr,
+        unit = unitLabel
+    )
+
+    Spacer(Modifier.height(16.dp))
+
+    if (hasBuffer) {
+        val windowSamples = samples
+
+        val boundsFor: (Float, Float) -> GraphBounds = when (legacyType) {
+            MetricType.BATTERY -> { _, _ -> GraphScale.fixed(0f, 100f) }
+            MetricType.TEMPERATURE -> { mn, mx -> GraphScale.absolute(mn, mx, 5f) }
+            MetricType.LOAD -> { mn, mx -> GraphScale.absolute(mn, mx, 5f) }
+            MetricType.CURRENT -> { mn, mx -> GraphScale.absolute(mn, mx, 1f) }
+            MetricType.VOLTAGE -> { mn, mx -> GraphScale.pad(mn, mx, GraphScale.SPAN_VOLTAGE) }
+            MetricType.SPEED -> { mn, mx ->
+                GraphScale.pad(
+                    mn, mx, when (speedUnit) {
+                        "mph" -> GraphScale.SPAN_SPEED_MPH
+                        "ms" -> GraphScale.SPAN_SPEED_MS
+                        else -> GraphScale.SPAN_SPEED_KMH
+                    }
+                )
+            }
+            null -> { mn, mx -> GraphScale.pad(mn, mx, 1f) }
+        }
+
+        MetricGraph(
+            samples = windowSamples,
+            color = accentColor,
+            boundsFor = boundsFor,
+            unitLabel = unitLabel,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(280.dp)
+        )
+    } else {
+        EmptyGraph(
+            color = accentColor,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(200.dp)
+        )
+    }
+}
+
+/**
+ * Primary stat card: label small on top, big value below, accent-tinted
+ * background so the card reads as a chip rather than a spreadsheet cell.
+ * Unit always renders with a leading space ("12.3 mph"), and dash-only
+ * placeholders ("--") drop the unit entirely so the empty state doesn't
+ * read as "--mph".
+ */
+@Composable
+private fun StatPill(
+    label: String,
+    value: String,
+    unit: String,
+    accent: Color,
+    modifier: Modifier = Modifier
+) {
+    val showUnit = unit.isNotBlank() && value.any { it.isDigit() }
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(accent.copy(alpha = 0.10f))
+            .padding(vertical = 10.dp, horizontal = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            label.uppercase(),
+            fontSize = 10.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontWeight = FontWeight.Medium,
+            letterSpacing = 0.5.sp
+        )
+        Spacer(Modifier.height(2.dp))
+        Text(
+            buildString {
+                append(value)
+                if (showUnit) {
+                    append(' ')
+                    append(unit)
+                }
+            },
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Bold,
+            color = accent,
+            maxLines = 1
+        )
+    }
+}
+
+/**
+ * Secondary stats footer — Median / P95 / N samples / time-window. Rendered
+ * as small label·value chips in a single row so the supporting numbers
+ * stay reachable without competing with the three primary pills above.
+ */
+@Composable
+private fun StatSecondaryRow(
+    median: String,
+    p95: String,
+    count: String,
+    duration: String,
+    unit: String
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        SecondaryStatChip("Median", median, unit, modifier = Modifier.weight(1f))
+        SecondaryStatChip("P95", p95, unit, modifier = Modifier.weight(1f))
+        SecondaryStatChip("N", count, "", modifier = Modifier.weight(1f))
+        SecondaryStatChip("Time", duration, "", modifier = Modifier.weight(1f))
+    }
+}
+
+@Composable
+private fun SecondaryStatChip(
+    label: String,
+    value: String,
+    unit: String,
+    modifier: Modifier = Modifier
+) {
+    val showUnit = unit.isNotBlank() && value.any { it.isDigit() }
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            label.uppercase(),
+            fontSize = 9.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontWeight = FontWeight.Medium,
+            letterSpacing = 0.5.sp
+        )
+        Text(
+            buildString {
+                append(value)
+                if (showUnit) {
+                    append(' ')
+                    append(unit)
+                }
+            },
+            fontSize = 13.sp,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1
+        )
     }
 }
 
@@ -231,11 +584,10 @@ private fun EmptyGraph(
     color: Color,
     modifier: Modifier = Modifier
 ) {
-    val gridColor = MaterialTheme.colorScheme.surfaceVariant
+    val gridColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.15f)
     val labelColor = MaterialTheme.colorScheme.onSurfaceVariant
-    val textMeasurer = rememberTextMeasurer()
     val noDataLabel = stringResource(R.string.metric_no_data)
-
+    val textMeasurer = rememberTextMeasurer()
     Box(
         modifier = modifier
             .clip(RoundedCornerShape(12.dp))
@@ -250,7 +602,6 @@ private fun EmptyGraph(
             val h = size.height
             val dash = PathEffect.dashPathEffect(floatArrayOf(6f, 6f))
 
-            // Grid lines
             for (i in 0..4) {
                 val y = h - h * i / 4f
                 drawLine(gridColor, Offset(0f, y), Offset(w, y), strokeWidth = 1f, pathEffect = dash)
@@ -260,7 +611,6 @@ private fun EmptyGraph(
                 drawLine(gridColor, Offset(x, 0f), Offset(x, h), strokeWidth = 1f, pathEffect = dash)
             }
 
-            // Flat dashed line in the middle
             drawLine(
                 color = color.copy(alpha = 0.3f),
                 start = Offset(0f, h / 2f),
@@ -269,7 +619,6 @@ private fun EmptyGraph(
                 pathEffect = PathEffect.dashPathEffect(floatArrayOf(10f, 10f))
             )
 
-            // "No data" text
             val noData = textMeasurer.measure(noDataLabel, TextStyle(fontSize = 14.sp, color = labelColor))
             drawText(noData, topLeft = Offset(w / 2f - noData.size.width / 2f, h / 2f - noData.size.height - 8f))
         }
@@ -280,287 +629,105 @@ private fun EmptyGraph(
 private fun MetricGraph(
     samples: List<MetricSample>,
     color: Color,
-    boundsFor: (dataMin: Float, dataMax: Float) -> GraphBounds,
+    boundsFor: (Float, Float) -> GraphBounds,
     unitLabel: String,
-    regenColor: Color = AccentGreen,
     modifier: Modifier = Modifier
 ) {
+    val gridColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.15f)
+    val axisLabelColor = MaterialTheme.colorScheme.onSurfaceVariant
     val textMeasurer = rememberTextMeasurer()
-    val gridColor = MaterialTheme.colorScheme.surfaceVariant
-    val labelColor = MaterialTheme.colorScheme.onSurfaceVariant
-    val tooltipBg = MaterialTheme.colorScheme.surfaceVariant
-    val tooltipFg = MaterialTheme.colorScheme.onSurface
+    val values = samples.map { it.value }
+    val minRaw = values.min()
+    val maxRaw = values.max()
+    val bounds = boundsFor(minRaw, maxRaw)
+    val padded = bounds.max - bounds.min
 
-    var touchX by remember { mutableStateOf<Float?>(null) }
-    var frozenSamples by remember { mutableStateOf<List<MetricSample>?>(null) }
-    val latestSamples = rememberUpdatedState(samples)
-
-    // Zoom state. zoomTarget = 1f means "see the full window"; 2f means
-    // "see half the time range centered on panFractionTarget". The animated
-    // values drive rendering so resets snap smoothly back to 1.0 over ~250ms.
-    var zoomTarget by remember { mutableStateOf(1f) }
-    var panFractionTarget by remember { mutableStateOf(0.5f) }
-    val zoom by animateFloatAsState(
-        targetValue = zoomTarget,
-        animationSpec = tween(250),
-        label = "graphZoom"
-    )
-    val panFraction by animateFloatAsState(
-        targetValue = panFractionTarget,
-        animationSpec = tween(250),
-        label = "graphPan"
-    )
-    val isZoomed = zoomTarget > 1.001f
-
-    // While zoomed we keep the snapshot frozen so live samples don't push the
-    // user's zoomed-in moment off the right edge. Reset both together.
-    val resetZoom = {
-        zoomTarget = 1f
-        panFractionTarget = 0.5f
-        frozenSamples = null
-        touchX = null
-    }
-
-    val displaySamples = frozenSamples ?: samples
+    var hoverX by remember { mutableStateOf<Float?>(null) }
+    val updatedSamples = rememberUpdatedState(samples)
 
     Box(
         modifier = modifier
             .clip(RoundedCornerShape(12.dp))
             .background(MaterialTheme.colorScheme.surface)
+            .pointerInput(samples) {
+                awaitEachGesture {
+                    val down = awaitFirstDown(requireUnconsumed = false)
+                    hoverX = down.position.x
+                    while (true) {
+                        val event = awaitPointerEvent()
+                        val anyPressed = event.changes.any { it.pressed }
+                        if (!anyPressed) break
+                        event.changes.firstOrNull()?.let { hoverX = it.position.x }
+                    }
+                    hoverX = null
+                }
+            }
+            .pointerInput(Unit) {
+                detectTapGestures(onTap = { hoverX = null })
+            }
     ) {
         Canvas(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(start = 44.dp, bottom = 28.dp, top = 12.dp, end = 12.dp)
-                // Double-tap anywhere resets zoom + unfreezes live data. Runs
-                // on its own pointerInput so it composes cleanly with the
-                // scrub / pinch handler below, tap detection only fires on
-                // quick taps so it doesn't shadow press-and-hold scrubbing.
-                .pointerInput(Unit) {
-                    detectTapGestures(onDoubleTap = { resetZoom() })
-                }
-                .pointerInput(Unit) {
-                    awaitEachGesture {
-                        awaitFirstDown(requireUnconsumed = false)
-                        // Snapshot current samples; if we're not already
-                        // zoomed, this also freezes the live-slide.
-                        if (frozenSamples == null) frozenSamples = latestSamples.value
-
-                        // Pinch tracking. We capture the time-fraction under
-                        // the pinch midpoint at gesture start so the zoom
-                        // anchors to where the user's fingers are, instead
-                        // of always centering on the middle of the window.
-                        var initialPinchDist: Float? = null
-                        var initialZoom = zoomTarget
-                        var anchorTimeFrac = 0.5f
-                        var pinchFracStart = 0.5f
-
-                        while (true) {
-                            val ev = awaitPointerEvent()
-                            val pressed = ev.changes.filter { it.pressed }
-                            if (pressed.isEmpty()) break
-
-                            if (pressed.size >= 2) {
-                                // Two-finger pinch. Hide tooltip and start
-                                // (or continue) a zoom session.
-                                touchX = null
-                                val p1 = pressed[0].position
-                                val p2 = pressed[1].position
-                                val dist = (p1 - p2).getDistance()
-                                if (initialPinchDist == null) {
-                                    initialPinchDist = dist
-                                    initialZoom = zoomTarget
-                                    pinchFracStart = ((p1.x + p2.x) / 2f / size.width)
-                                        .coerceIn(0f, 1f)
-                                    val visStart = panFractionTarget - 0.5f / zoomTarget
-                                    val visWidth = 1f / zoomTarget
-                                    anchorTimeFrac = (visStart + pinchFracStart * visWidth)
-                                        .coerceIn(0f, 1f)
-                                } else {
-                                    val scale = dist / initialPinchDist!!
-                                    val newZoom = (initialZoom * scale).coerceIn(1f, 20f)
-                                    zoomTarget = newZoom
-                                    val newPan = anchorTimeFrac +
-                                        (0.5f - pinchFracStart) / newZoom
-                                    val halfVis = 0.5f / newZoom
-                                    panFractionTarget = newPan.coerceIn(halfVis, 1f - halfVis)
-                                }
-                            } else {
-                                // Single finger, scrub for tooltip.
-                                initialPinchDist = null
-                                touchX = pressed[0].position.x
-                            }
-                            ev.changes.forEach { it.consume() }
-                        }
-
-                        // All fingers released. Drop tooltip; unfreeze the
-                        // sample list only if we're NOT still zoomed in.
-                        touchX = null
-                        if (zoomTarget <= 1.001f) frozenSamples = null
-                    }
-                }
         ) {
-            if (displaySamples.size < 2) return@Canvas
             val w = size.width
             val h = size.height
-
-            // Apply zoom: pick the slice of displaySamples in the visible
-            // time window. The window has width 1/zoom and is centered on
-            // panFraction (both in [0..1] of the full snapshot's time range).
-            val fullStart = displaySamples.first().timestampMs
-            val fullEnd = displaySamples.last().timestampMs
-            val fullSpanMs = (fullEnd - fullStart).coerceAtLeast(1)
-            val halfVis = 0.5f / zoom
-            val visStartFrac = (panFraction - halfVis).coerceIn(0f, 1f - 2 * halfVis)
-            val visEndFrac = (visStartFrac + 2 * halfVis).coerceAtMost(1f)
-            val visStartMs = fullStart + (visStartFrac * fullSpanMs).toLong()
-            val visEndMs = fullStart + (visEndFrac * fullSpanMs).toLong()
-            val visibleSamples = if (zoom <= 1.001f) {
-                displaySamples
-            } else {
-                displaySamples.filter { it.timestampMs in visStartMs..visEndMs }
-                    .ifEmpty { displaySamples }
-            }
-
-            val values = visibleSamples.map { it.value }
-            val bounds = boundsFor(values.min(), values.max())
-            val graphMin = bounds.min
-            val graphRange = bounds.range
-
             val dash = PathEffect.dashPathEffect(floatArrayOf(6f, 6f))
 
-            // Horizontal grid lines (5 lines)
             for (i in 0..4) {
                 val y = h - h * i / 4f
-                val v = graphMin + graphRange * i / 4f
                 drawLine(gridColor, Offset(0f, y), Offset(w, y), strokeWidth = 1f, pathEffect = dash)
-                val label = "%.0f".format(v)
-                val measured = textMeasurer.measure(label, TextStyle(fontSize = 9.sp, color = labelColor))
-                drawText(measured, topLeft = Offset(-measured.size.width - 4f, y - measured.size.height / 2f))
+                val value = bounds.min + padded * i / 4f
+                val label = textMeasurer.measure(
+                    "%.0f".format(value), TextStyle(fontSize = 10.sp, color = axisLabelColor)
+                )
+                drawText(label, topLeft = Offset(-label.size.width - 6f, y - label.size.height / 2f))
             }
-
-            // Time axis labels, reflect the currently-visible zoom window.
-            val startTime = visibleSamples.first().timestampMs
-            val endTime = visibleSamples.last().timestampMs
-            val totalSec = ((endTime - startTime) / 1000).toInt().coerceAtLeast(1)
-            val timeSteps = if (totalSec > 300) 5 else if (totalSec > 60) 4 else 3
-            for (i in 0..timeSteps) {
-                val x = w * i / timeSteps.toFloat()
-                val sec = totalSec * i / timeSteps
+            val timeSpanSec = ((samples.last().timestampMs - samples.first().timestampMs) / 1000).coerceAtLeast(1L)
+            for (i in 0..3) {
+                val x = w * i / 3f
                 drawLine(gridColor, Offset(x, 0f), Offset(x, h), strokeWidth = 1f, pathEffect = dash)
-                val label = formatDuration(sec.toLong())
-                val measured = textMeasurer.measure(label, TextStyle(fontSize = 9.sp, color = labelColor))
-                drawText(measured, topLeft = Offset(x - measured.size.width / 2f, h + 4f))
+                val secondsAgo = timeSpanSec * (3 - i) / 3
+                val label = textMeasurer.measure(
+                    "-${secondsAgo}s", TextStyle(fontSize = 10.sp, color = axisLabelColor)
+                )
+                drawText(label, topLeft = Offset(x - label.size.width / 2f, h + 6f))
             }
 
-            // Data line, only samples in the visible window are drawn.
-            val timeRange = (endTime - startTime).coerceAtLeast(1)
+            // Build path
             val path = androidx.compose.ui.graphics.Path()
-            visibleSamples.forEachIndexed { idx, sample ->
-                val x = ((sample.timestampMs - startTime).toFloat() / timeRange) * w
-                val y = h - ((sample.value - graphMin) / graphRange) * h
+            samples.forEachIndexed { idx, s ->
+                val x = w * (s.timestampMs - samples.first().timestampMs).toFloat() /
+                    (samples.last().timestampMs - samples.first().timestampMs).coerceAtLeast(1).toFloat()
+                val y = h - h * (s.value - bounds.min) / padded.coerceAtLeast(0.001f)
                 if (idx == 0) path.moveTo(x, y) else path.lineTo(x, y)
             }
-
-            // Filled area. When the metric is bipolar, current crossing zero,
-            // i.e. regen braking, the fill and line split at the zero baseline
-            // and everything below zero is drawn in [regenColor] so the regen
-            // stretches stand out. Single-polarity metrics keep the plain
-            // curve-to-bottom fill.
-            val graphMax = graphMin + graphRange
-            if (graphMin < 0f && graphMax > 0f) {
-                val zeroY = h - ((0f - graphMin) / graphRange) * h
-                val fillPath = androidx.compose.ui.graphics.Path()
-                fillPath.addPath(path)
-                fillPath.lineTo(w, zeroY)
-                fillPath.lineTo(0f, zeroY)
-                fillPath.close()
-                clipRect(top = 0f, bottom = zeroY) {
-                    drawPath(fillPath, color = color.copy(alpha = 0.18f))
-                    drawPath(path, color = color, style = Stroke(width = 2.5f))
-                }
-                clipRect(top = zeroY, bottom = h) {
-                    drawPath(fillPath, color = regenColor.copy(alpha = 0.18f))
-                    drawPath(path, color = regenColor, style = Stroke(width = 2.5f))
-                }
-                drawLine(gridColor, Offset(0f, zeroY), Offset(w, zeroY), strokeWidth = 1.5f)
-            } else {
-                val fillPath = androidx.compose.ui.graphics.Path()
-                fillPath.addPath(path)
-                fillPath.lineTo(w, h)
-                fillPath.lineTo(0f, h)
-                fillPath.close()
+            val fillPath = androidx.compose.ui.graphics.Path()
+            fillPath.addPath(path)
+            fillPath.lineTo(w, h)
+            fillPath.lineTo(0f, h)
+            fillPath.close()
+            clipRect(0f, 0f, w, h) {
                 drawPath(fillPath, color = color.copy(alpha = 0.1f))
-                drawPath(path, color = color, style = Stroke(width = 2.5f))
-            }
-
-            // Touch crosshair, vertical line follows finger, dot interpolates on the curve
-            val tx = touchX
-            if (tx != null) {
-                val cursorX = tx.coerceIn(0f, w)
-                val targetMs = startTime + (cursorX / w * timeRange).toLong()
-
-                // Find bracketing samples for interpolation
-                var leftIdx = 0
-                for (i in visibleSamples.indices) {
-                    if (visibleSamples[i].timestampMs <= targetMs) leftIdx = i else break
-                }
-                val rightIdx = (leftIdx + 1).coerceAtMost(visibleSamples.size - 1)
-                val left = visibleSamples[leftIdx]
-                val right = visibleSamples[rightIdx]
-                val span = (right.timestampMs - left.timestampMs).coerceAtLeast(1)
-                val frac = ((targetMs - left.timestampMs).toFloat() / span).coerceIn(0f, 1f)
-                val interpValue = left.value + (right.value - left.value) * frac
-                val cursorY = h - ((interpValue - graphMin) / graphRange) * h
-
-                drawLine(color.copy(alpha = 0.5f), Offset(cursorX, 0f), Offset(cursorX, h), strokeWidth = 1.5f)
-                drawCircle(color, radius = 5f, center = Offset(cursorX, cursorY))
-                drawCircle(androidx.compose.ui.graphics.Color.White, radius = 2.5f, center = Offset(cursorX, cursorY))
-
-                val valText = "%.1f %s".format(interpValue, unitLabel)
-                val timeText = formatDuration(((targetMs - startTime) / 1000).coerceAtLeast(0))
-                val labelText = "$valText · $timeText"
-                val measured = textMeasurer.measure(labelText, TextStyle(fontSize = 11.sp, color = tooltipFg, fontWeight = FontWeight.Medium))
-                val padX = 6f
-                val padY = 3f
-                val boxW = measured.size.width + padX * 2
-                val boxH = measured.size.height + padY * 2
-                val boxX = (cursorX - boxW / 2f).coerceIn(0f, w - boxW)
-                val boxY = (cursorY - boxH - 10f).coerceAtLeast(0f)
-                drawRoundRect(
-                    color = tooltipBg,
-                    topLeft = Offset(boxX, boxY),
-                    size = Size(boxW, boxH),
-                    cornerRadius = androidx.compose.ui.geometry.CornerRadius(6f, 6f)
-                )
-                drawText(measured, topLeft = Offset(boxX + padX, boxY + padY))
+                drawPath(path, color = color, style = Stroke(width = 3f))
             }
         }
 
-        // ▶ Live chip, only shown while a zoom is active. Tap to snap back
-        // and resume live sliding. Doubles as the "you are paused" indicator
-        // so the user has an obvious way out of the inspection mode.
-        AnimatedVisibility(
-            visible = isZoomed,
-            enter = fadeIn(tween(150)),
-            exit = fadeOut(tween(150)),
-            modifier = Modifier
-                .align(Alignment.TopEnd)
-                .padding(top = 8.dp, end = 8.dp)
-        ) {
-            Box(
-                modifier = Modifier
-                    .clip(RoundedCornerShape(14.dp))
-                    .background(color.copy(alpha = 0.85f))
-                    .clickable { resetZoom() }
-                    .padding(horizontal = 10.dp, vertical = 4.dp)
-            ) {
-                Text(
-                    text = "Reset",
-                    fontSize = 11.sp,
-                    fontWeight = FontWeight.Medium,
-                    color = Color.Black
-                )
+        // Crosshair + tooltip
+        AnimatedVisibility(visible = hoverX != null, enter = fadeIn(animationSpec = tween(150)), exit = fadeOut()) {
+            val x = hoverX ?: return@AnimatedVisibility
+            Box(modifier = Modifier.fillMaxSize()) {
+                Canvas(modifier = Modifier.fillMaxSize().padding(start = 44.dp, bottom = 28.dp, top = 12.dp, end = 12.dp)) {
+                    val padLeft = 0f
+                    val padRight = size.width
+                    val xClamped = (x - 44f).coerceIn(padLeft, padRight)
+                    drawLine(
+                        color = Color.White.copy(alpha = 0.4f),
+                        start = Offset(xClamped, 0f), end = Offset(xClamped, size.height),
+                        strokeWidth = 1.5f
+                    )
+                }
             }
         }
     }
@@ -569,5 +736,5 @@ private fun MetricGraph(
 private fun formatDuration(seconds: Long): String {
     val m = seconds / 60
     val s = seconds % 60
-    return if (m > 0) "${m}m${s}s" else "${s}s"
+    return "${m}:${"%02d".format(s)}"
 }

--- a/app/src/main/java/com/eried/eucplanet/ui/dashboard/MetricDetailViewModel.kt
+++ b/app/src/main/java/com/eried/eucplanet/ui/dashboard/MetricDetailViewModel.kt
@@ -31,4 +31,10 @@ class MetricDetailViewModel @Inject constructor(
     val tempUnit: StateFlow<String> = settingsRepository.settings
         .map { com.eried.eucplanet.util.Units.effectiveTempUnit(it) }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), "C")
+
+    /** Wipe this metric's rolling history; new samples re-seed at the next 1Hz tick. */
+    fun resetHistory(key: String) = wheelRepository.resetHistory(key)
+
+    /** Wipe every metric's rolling history. */
+    fun resetAllHistory() = wheelRepository.resetAllHistory()
 }

--- a/app/src/main/java/com/eried/eucplanet/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/eried/eucplanet/ui/navigation/NavGraph.kt
@@ -20,7 +20,6 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.eried.eucplanet.ui.dashboard.DashboardScreen
 import com.eried.eucplanet.ui.dashboard.MetricDetailScreen
-import com.eried.eucplanet.ui.dashboard.MetricType
 import com.eried.eucplanet.ui.navigator.RouteBuilderScreen
 import com.eried.eucplanet.ui.recording.EucViewerScreen
 import com.eried.eucplanet.ui.recording.RecordingScreen
@@ -223,19 +222,29 @@ fun NavGraph(navController: NavHostController) {
             arguments = listOf(navArgument("metric") { type = NavType.StringType })
         ) { backStackEntry ->
             val metricName = backStackEntry.arguments?.getString("metric")
-            val metricType = metricName?.let {
-                try { MetricType.valueOf(it) } catch (_: Exception) { null }
-            }
-            if (metricType != null) {
-                MetricDetailScreen(
-                    metricType = metricType,
-                    onBack = { navController.popSingle() }
-                )
-            } else {
+            if (metricName.isNullOrBlank()) {
                 LaunchedEffect(metricName) {
-                    Log.w("EucNav", "MetricDetail: invalid metric '$metricName', popping back")
+                    Log.w("EucNav", "MetricDetail: blank metric key, popping back")
                     navController.popBackStack()
                 }
+            } else {
+                // Route argument shape:
+                //   "BATTERY"                  → single tab
+                //   "SPEED,BATTERY,POWER"      → 3 tabs, default initial 0
+                //   "SPEED,BATTERY,POWER|2"    → 3 tabs, pre-select POWER
+                // The "|<index>" suffix is optional and lets the composite
+                // tile side-tap pre-select a specific tab WITHOUT changing
+                // the tab order — riders see the same strip regardless of
+                // which sub-tile they tapped on the dashboard.
+                val (keysPart, idxPart) = metricName.split("|", limit = 2)
+                    .let { if (it.size == 2) it[0] to it[1] else metricName to "0" }
+                val keys = keysPart.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+                val initialIdx = idxPart.toIntOrNull()?.coerceIn(0, (keys.size - 1).coerceAtLeast(0)) ?: 0
+                MetricDetailScreen(
+                    metricKeys = keys,
+                    initialTabIndex = initialIdx,
+                    onBack = { navController.popSingle() }
+                )
             }
         }
     }

--- a/app/src/main/java/com/eried/eucplanet/ui/settings/DashboardDragController.kt
+++ b/app/src/main/java/com/eried/eucplanet/ui/settings/DashboardDragController.kt
@@ -1,0 +1,433 @@
+package com.eried.eucplanet.ui.settings
+
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+
+/**
+ * Drag-and-drop coordinator for the dashboard layout editor. Owns the active-
+ * drag state (which item, source kind, current pointer position) and the
+ * registered drop targets. Backed entirely by Compose pointer input so we can
+ * animate the floating preview's size / alpha during the drag — something
+ * Compose's built-in `dragAndDropSource` (which uses the View-level system
+ * drag shadow) doesn't allow.
+ *
+ * Drag flow:
+ * 1. Tile or pool pill calls [startDrag] from `detectDragGesturesAfterLongPress`.
+ * 2. Each subsequent drag delta is applied via [movePointer].
+ * 3. While dragging, [hoveredTarget] re-derives from pointer + target bounds.
+ * 4. On finger lift, [commitDrop] invokes the hovered target's `onDrop` if any.
+ *
+ * Only grid slots register as drop targets; the pool stays a source-only
+ * region so dragging outside the active grid reads as "no valid drop".
+ */
+@Stable
+class DashboardDragController {
+
+    var draggingKey: String? by mutableStateOf(null)
+        private set
+    var draggingValue: String by mutableStateOf("")
+        private set
+    var sourceKind: DragSourceKind? by mutableStateOf(null)
+        private set
+    var sourceSizePx: IntSize by mutableStateOf(IntSize.Zero)
+        private set
+    var pointerWindowPos: Offset? by mutableStateOf(null)
+        private set
+    /**
+     * True when the rider started this drag from a big tile in the active
+     * grid; false when it started from a pool pill (catalog source) or a
+     * pool template. Drop handlers read this to decide between SWAP
+     * (grid → grid), COPY (pool → grid, pool stays full), and discard
+     * (grid → pool).
+     */
+    var sourceFromGrid: Boolean by mutableStateOf(false)
+        private set
+
+    /**
+     * Latched preview size for the floating drag overlay. Updates only when
+     * the pointer enters a registered drop target or hint region — never on
+     * pointer-exit. This implements the "once it grew, keep it grown until I
+     * drag it back to the pool" behaviour: the preview holds its last
+     * recognised size as the rider sweeps through empty space, and only
+     * shrinks when they re-enter the pool's hint region.
+     */
+    var previewSizePx: IntSize by mutableStateOf(IntSize.Zero)
+        private set
+
+    private val targets = mutableStateMapOf<String, DropTargetInfo>()
+    private val hintRegions = mutableStateMapOf<String, HintRegionInfo>()
+
+    /** Target the pointer is currently over, or null if outside every drop area. */
+    val hoveredTarget: DropTargetInfo? by derivedStateOf {
+        val pos = pointerWindowPos ?: return@derivedStateOf null
+        val source = sourceKind ?: return@derivedStateOf null
+        val key = draggingKey ?: return@derivedStateOf null
+        targets.values.firstOrNull { it.accepts(source, key) && it.bounds.contains(pos) }
+    }
+
+    val isDragging: Boolean
+        get() = draggingKey != null
+
+    fun startDrag(
+        key: String,
+        value: String,
+        sourceKind: DragSourceKind,
+        sourceSize: IntSize,
+        pointerWindowPos: Offset,
+        sourceFromGrid: Boolean
+    ) {
+        this.draggingKey = key
+        this.draggingValue = value
+        this.sourceKind = sourceKind
+        this.sourceSizePx = sourceSize
+        this.pointerWindowPos = pointerWindowPos
+        this.previewSizePx = sourceSize
+        this.sourceFromGrid = sourceFromGrid
+    }
+
+    fun movePointer(delta: Offset) {
+        val current = pointerWindowPos ?: return
+        val source = sourceKind ?: return
+        val key = draggingKey ?: return
+        val newPos = current + delta
+        pointerWindowPos = newPos
+
+        // Latch preview size to whatever region the pointer just entered.
+        // Drop targets win over hint regions when both contain the pointer.
+        val hit = targets.values.firstOrNull { it.accepts(source, key) && it.bounds.contains(newPos) }
+            ?.expectedSizePx
+            ?: hintRegions.values.firstOrNull { it.accepts(source) && it.bounds.contains(newPos) }
+                ?.expectedSizePx
+        if (hit != null) previewSizePx = hit
+    }
+
+    fun commitDrop() {
+        val key = draggingKey
+        val target = hoveredTarget
+        if (key != null && target != null) {
+            target.onDrop(key)
+        }
+        resetDrag()
+    }
+
+    fun cancelDrag() {
+        resetDrag()
+    }
+
+    private fun resetDrag() {
+        draggingKey = null
+        sourceKind = null
+        pointerWindowPos = null
+    }
+
+    fun registerTarget(info: DropTargetInfo) {
+        targets[info.key] = info
+    }
+
+    fun unregisterTarget(key: String) {
+        targets.remove(key)
+    }
+
+    fun registerHintRegion(info: HintRegionInfo) {
+        hintRegions[info.key] = info
+    }
+}
+
+enum class DragSourceKind { METRIC, ACTION }
+
+enum class DropKind {
+    METRIC_GRID_SLOT,
+    ACTION_GRID_SLOT,
+    /** Pool acts as a "drag-off-to-delete" trash for composite/group instances. */
+    METRIC_POOL_TRASH,
+    ACTION_POOL_TRASH
+}
+
+data class DropTargetInfo(
+    val key: String,
+    val kind: DropKind,
+    val bounds: Rect,
+    /** Size the floating preview should animate to while hovering this target. */
+    val expectedSizePx: IntSize,
+    /** Index within the active grid (0..N-1) for grid-slot targets; -1 otherwise. */
+    val slotIndex: Int,
+    val onDrop: (sourceKey: String) -> Unit,
+    /**
+     * Optional per-source-key acceptance check. When set, the target only
+     * highlights and accepts drops for keys that pass this predicate. Used
+     * by the pool trash targets, which exist exclusively to delete
+     * composite/group instances (and shouldn't react to regular pool pills
+     * or template keys being dragged back over them).
+     */
+    val acceptsSourceKey: ((String) -> Boolean)? = null
+) {
+    fun accepts(source: DragSourceKind, sourceKey: String): Boolean {
+        val kindAllows = when (source) {
+            DragSourceKind.METRIC -> kind == DropKind.METRIC_GRID_SLOT || kind == DropKind.METRIC_POOL_TRASH
+            DragSourceKind.ACTION -> kind == DropKind.ACTION_GRID_SLOT || kind == DropKind.ACTION_POOL_TRASH
+        }
+        return kindAllows && (acceptsSourceKey?.invoke(sourceKey) ?: true)
+    }
+}
+
+/**
+ * A non-drop region whose only purpose is to influence the preview size.
+ * The pool registers as a hint region so the dragged tile shrinks back to
+ * its source size when the rider drags it back over the pool, but a drop
+ * over the pool is still ignored (only drop targets accept drops).
+ */
+data class HintRegionInfo(
+    val key: String,
+    val sourceKind: DragSourceKind,
+    val bounds: Rect,
+    val expectedSizePx: IntSize
+) {
+    fun accepts(source: DragSourceKind): Boolean = source == sourceKind
+}
+
+/**
+ * Attaches drag-source behaviour to a tile/pill: long-press starts a drag,
+ * subsequent moves update the controller's pointer position, lift commits a
+ * drop. Tap events fall through to a sibling `.clickable(...)` modifier
+ * because `detectDragGesturesAfterLongPress` only consumes events once the
+ * long-press timeout fires.
+ */
+fun Modifier.dashboardDragSource(
+    key: String,
+    value: String,
+    sourceKind: DragSourceKind,
+    controller: DashboardDragController,
+    /**
+     * True when this drag-source is a big tile in the active grid; false
+     * for pool pills and templates. Controls SWAP vs COPY semantics in
+     * the drop handlers: grid sources reorder, pool sources spawn into
+     * the target slot leaving the catalog untouched.
+     */
+    fromGrid: Boolean
+): Modifier = composed {
+    var sourceWindowPos by remember { mutableStateOf(Offset.Zero) }
+    var sourceSize by remember { mutableStateOf(IntSize.Zero) }
+    this
+        .onGloballyPositioned { coords ->
+            sourceWindowPos = coords.positionInWindow()
+            sourceSize = coords.size
+        }
+        .pointerInput(key, sourceKind) {
+            detectDragGesturesAfterLongPress(
+                onDragStart = { localOffset ->
+                    controller.startDrag(
+                        key = key,
+                        value = value,
+                        sourceKind = sourceKind,
+                        sourceSize = sourceSize,
+                        pointerWindowPos = sourceWindowPos + localOffset,
+                        sourceFromGrid = fromGrid
+                    )
+                },
+                onDrag = { change, dragAmount ->
+                    controller.movePointer(dragAmount)
+                    change.consume()
+                },
+                onDragEnd = { controller.commitDrop() },
+                onDragCancel = { controller.cancelDrag() }
+            )
+        }
+}
+
+/**
+ * Attaches drop-target behaviour. The target's bounds are tracked via
+ * `onGloballyPositioned` so the controller can hit-test the pointer at any
+ * moment. [expectedSizePx] is the size the floating preview animates to when
+ * hovering this target — pass the slot's measured size so a pool pill that's
+ * being promoted to the grid visibly grows.
+ */
+fun Modifier.dashboardDropTarget(
+    key: String,
+    kind: DropKind,
+    slotIndex: Int = -1,
+    controller: DashboardDragController,
+    onDrop: (sourceKey: String) -> Unit,
+    acceptsSourceKey: ((String) -> Boolean)? = null,
+    /**
+     * If non-null, the drag preview shrinks/grows to this size while hovering
+     * the target instead of matching the target's own measured size. Pool
+     * trash targets pass `poolPillSizePx` so a composite tile dragged over
+     * them previews at pill size — signalling "release = delete (back to
+     * pool)" rather than "release = land here at full grid size".
+     */
+    overrideExpectedSizePx: IntSize? = null
+): Modifier = composed {
+    onGloballyPositioned { coords ->
+        controller.registerTarget(
+            DropTargetInfo(
+                key = key,
+                kind = kind,
+                bounds = coords.boundsInWindow(),
+                expectedSizePx = overrideExpectedSizePx ?: coords.size,
+                slotIndex = slotIndex,
+                onDrop = onDrop,
+                acceptsSourceKey = acceptsSourceKey
+            )
+        )
+    }
+}
+
+/**
+ * Registers a hint region that influences only the floating preview size,
+ * not drop acceptance. Use on the pool container so a pool pill that's been
+ * dragged up into the grid (and grown) shrinks back to its source size when
+ * the rider drags it over the pool again.
+ */
+fun Modifier.dashboardHintRegion(
+    key: String,
+    sourceKind: DragSourceKind,
+    expectedSizePx: IntSize,
+    controller: DashboardDragController
+): Modifier = composed {
+    onGloballyPositioned { coords ->
+        controller.registerHintRegion(
+            HintRegionInfo(
+                key = key,
+                sourceKind = sourceKind,
+                bounds = coords.boundsInWindow(),
+                expectedSizePx = expectedSizePx
+            )
+        )
+    }
+}
+
+/**
+ * Floating drag preview. Rendered as a plain `Box` positioned via
+ * `Modifier.offset` so it stays in the same composition tree as the editor
+ * and does not consume touch events that the underlying tile's `pointerInput`
+ * still needs. (Compose's `Popup` allocates a separate WindowManager window
+ * with `FLAG_NOT_TOUCH_MODAL`; touches inside that window's bounds are
+ * captured by it rather than passing through to the editor, which freezes
+ * the drag the moment the preview overlays the rider's finger.)
+ *
+ * Size animates between source size and the hovered target's expected size,
+ * so a pool pill grows on its way into the grid and a grid tile shrinks on
+ * its way out. Alpha animates to 0.4 when no valid drop target is under the
+ * pointer, signalling "release here = no-op".
+ *
+ * @param rootInWindow the editor root's window-coordinate offset, captured
+ *   by the caller via `onGloballyPositioned`. Used to convert the
+ *   controller's window-space pointer into local coordinates so the offset
+ *   modifier places the preview correctly within the editor's bounds.
+ */
+@Composable
+fun DashboardDragPreviewOverlay(
+    controller: DashboardDragController,
+    rootInWindow: Offset,
+    renderMetric: @Composable (key: String, value: String) -> Unit,
+    renderAction: @Composable (key: String) -> Unit
+) {
+    val key = controller.draggingKey ?: return
+    val pos = controller.pointerWindowPos ?: return
+    val source = controller.sourceKind ?: return
+    val target = controller.hoveredTarget
+
+    // Only flag as a discard when the tile actually shrinks into the
+    // pool — i.e. the drag started on a big grid tile. A pool pill
+    // dragged up and back down again returns home (no slot is lost, no
+    // definition gets deleted), so the red wash would be misleading.
+    // Compare source size to the target's expected size: shrink == big
+    // origin == will be removed; same size == pool-to-pool == no-op.
+    val isPoolTrash = target?.kind == DropKind.METRIC_POOL_TRASH ||
+        target?.kind == DropKind.ACTION_POOL_TRASH
+    val isDiscardDrop = isPoolTrash &&
+        controller.sourceSizePx.height > (target?.expectedSizePx?.height ?: Int.MAX_VALUE)
+
+    val targetSize = controller.previewSizePx.takeIf { it.width > 0 && it.height > 0 }
+        ?: controller.sourceSizePx
+    val animWidth by animateFloatAsState(
+        targetValue = targetSize.width.toFloat(),
+        animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
+        label = "drag-w"
+    )
+    val animHeight by animateFloatAsState(
+        targetValue = targetSize.height.toFloat(),
+        animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
+        label = "drag-h"
+    )
+    val animAlpha by animateFloatAsState(
+        targetValue = when {
+            isDiscardDrop -> 0.55f
+            target != null -> 1f
+            else -> 0.4f
+        },
+        animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
+        label = "drag-alpha"
+    )
+    val redOverlayAlpha by animateFloatAsState(
+        targetValue = if (isDiscardDrop) 0.22f else 0f,
+        animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
+        label = "drag-red"
+    )
+
+    val density = LocalDensity.current
+    val widthDp = with(density) { animWidth.toDp() }
+    val heightDp = with(density) { animHeight.toDp() }
+
+    val localPos = pos - rootInWindow
+
+    Box(
+        modifier = Modifier
+            .offset {
+                IntOffset(
+                    x = (localPos.x - animWidth / 2f).toInt(),
+                    y = (localPos.y - animHeight / 2f).toInt()
+                )
+            }
+            .size(widthDp, heightDp)
+            .alpha(animAlpha)
+    ) {
+        when (source) {
+            DragSourceKind.METRIC -> renderMetric(key, controller.draggingValue)
+            DragSourceKind.ACTION -> renderAction(key)
+        }
+        // Translucent red wash sits on top of the rendered tile, clipped
+        // to the same rounded corners so it reads as part of the tile
+        // rather than a stray overlay. Animated alpha keeps the fade
+        // smooth as the rider passes in and out of the trash region.
+        if (redOverlayAlpha > 0f) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(Color(0xFFEF4444).copy(alpha = redOverlayAlpha))
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/eried/eucplanet/ui/settings/DashboardStatCompute.kt
+++ b/app/src/main/java/com/eried/eucplanet/ui/settings/DashboardStatCompute.kt
@@ -1,0 +1,48 @@
+package com.eried.eucplanet.ui.settings
+
+import com.eried.eucplanet.data.repository.MetricSample
+
+/**
+ * Shared computation for every place the dashboard surfaces a per-cell
+ * statistic (composite cell renderer, the slot-sheet preview, and the
+ * future per-corner stat readouts on the live grid).
+ *
+ * Returns null when there's not enough buffered data to satisfy the
+ * requested stat (callers render a placeholder dash in that case).
+ * [DashboardStat.CURRENT] falls back to [fallbackCurrent] when the
+ * history buffer is empty, so a freshly-spawned composite cell still
+ * shows the live wheel value before any 1Hz samples land.
+ */
+fun computeDashboardStatValue(
+    stat: DashboardStat,
+    samples: List<MetricSample>,
+    fallbackCurrent: Float
+): Float? {
+    if (stat == DashboardStat.CURRENT) {
+        return samples.lastOrNull()?.value ?: fallbackCurrent
+    }
+    if (samples.isEmpty()) return null
+    val values = samples.map { it.value }
+    return when (stat) {
+        DashboardStat.NONE -> null
+        DashboardStat.CURRENT -> fallbackCurrent
+        DashboardStat.MIN -> values.min()
+        DashboardStat.MAX, DashboardStat.SUSTAINED_PEAK -> values.max()
+        DashboardStat.AVG -> values.average().toFloat()
+        DashboardStat.MEDIAN -> percentileOf(values, 0.50)
+        DashboardStat.P75 -> percentileOf(values, 0.75)
+        DashboardStat.P95 -> percentileOf(values, 0.95)
+        DashboardStat.P99 -> percentileOf(values, 0.99)
+    }
+}
+
+private fun percentileOf(values: List<Float>, p: Double): Float {
+    val sorted = values.sorted()
+    if (sorted.isEmpty()) return 0f
+    val rank = (p * (sorted.size - 1)).coerceIn(0.0, (sorted.size - 1).toDouble())
+    val lo = kotlin.math.floor(rank).toInt()
+    val hi = kotlin.math.ceil(rank).toInt()
+    if (lo == hi) return sorted[lo]
+    val frac = (rank - lo).toFloat()
+    return sorted[lo] + (sorted[hi] - sorted[lo]) * frac
+}

--- a/app/src/main/java/com/eried/eucplanet/ui/settings/FlicScreen.kt
+++ b/app/src/main/java/com/eried/eucplanet/ui/settings/FlicScreen.kt
@@ -51,7 +51,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.eried.eucplanet.R
-import com.eried.eucplanet.data.model.FlicAction
 import com.eried.eucplanet.ui.common.HintText
 import com.eried.eucplanet.ui.theme.AccentBlue
 import com.eried.eucplanet.ui.theme.AccentRed
@@ -254,10 +253,16 @@ private fun ActionDropdown(
     onValueChange: (String) -> Unit
 ) {
     var expanded by remember { mutableStateOf(false) }
-    val currentAction = try {
-        FlicAction.valueOf(currentValue)
-    } catch (_: Exception) {
-        FlicAction.NONE
+    val flicKeys = remember {
+        com.eried.eucplanet.data.model.ActionCatalog.keysFor(
+            com.eried.eucplanet.data.model.ActionSurface.FLIC
+        )
+    }
+    val noneLabel = stringResource(R.string.flic_action_none)
+    val currentLabel = when {
+        currentValue.isEmpty() || currentValue == "NONE" -> noneLabel
+        else -> com.eried.eucplanet.data.model.ActionCatalog.byKey(currentValue)
+            ?.labelRes?.let { stringResource(it) } ?: noneLabel
     }
 
     ExposedDropdownMenuBox(
@@ -265,7 +270,7 @@ private fun ActionDropdown(
         onExpandedChange = { expanded = !expanded }
     ) {
         OutlinedTextField(
-            value = stringResource(currentAction.labelRes),
+            value = currentLabel,
             onValueChange = {},
             readOnly = true,
             label = { Text(label) },
@@ -278,11 +283,22 @@ private fun ActionDropdown(
             expanded = expanded,
             onDismissRequest = { expanded = false }
         ) {
-            FlicAction.entries.forEach { action ->
+            // "None" is a synthetic first option — represents the
+            // unbound state. The catalog itself doesn't carry a NONE
+            // entry because nothing fires it.
+            DropdownMenuItem(
+                text = { Text(noneLabel) },
+                onClick = {
+                    onValueChange("NONE")
+                    expanded = false
+                }
+            )
+            flicKeys.forEach { key ->
+                val spec = com.eried.eucplanet.data.model.ActionCatalog.byKey(key) ?: return@forEach
                 DropdownMenuItem(
-                    text = { Text(stringResource(action.labelRes)) },
+                    text = { Text(stringResource(spec.labelRes)) },
                     onClick = {
-                        onValueChange(action.name)
+                        onValueChange(key)
                         expanded = false
                     }
                 )

--- a/app/src/main/java/com/eried/eucplanet/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/eried/eucplanet/ui/settings/SettingsScreen.kt
@@ -1,8 +1,16 @@
 package com.eried.eucplanet.ui.settings
 
+import android.content.ClipData
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.animateBounds
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -14,6 +22,7 @@ import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -23,15 +32,24 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.draganddrop.dragAndDropSource
+import androidx.compose.foundation.draganddrop.dragAndDropTarget
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.automirrored.filled.VolumeDown
 import androidx.compose.material.icons.automirrored.filled.VolumeOff
+import androidx.compose.material.icons.filled.Restore
+import androidx.compose.material.icons.filled.SwapHoriz
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Alarm
 import androidx.compose.material.icons.filled.Archive
 import androidx.compose.material.icons.filled.AutoAwesome
@@ -41,8 +59,47 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.outlined.RadioButtonUnchecked
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Apps
+import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.Campaign
+import androidx.compose.material.icons.filled.Dashboard
+import androidx.compose.material.icons.filled.Done
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Link
+import androidx.compose.material.icons.filled.Map
+import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.filled.QrCode2
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Phone
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Save
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Send
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material.icons.filled.Widgets
+import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.material.icons.filled.DisplaySettings
 import androidx.compose.material.icons.filled.DragHandle
+import androidx.compose.material.icons.filled.FiberManualRecord
+import androidx.compose.material.icons.filled.Build
+import androidx.compose.material.icons.filled.FlashlightOn
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.PhotoCamera
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.RestartAlt
+import androidx.compose.material.icons.filled.BarChart
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Extension
 import androidx.compose.material.icons.filled.GraphicEq
@@ -71,8 +128,16 @@ import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.waitForUpOrCancellation
+import androidx.compose.ui.input.pointer.PointerEventTimeoutCancellationException
+import kotlinx.coroutines.withTimeout
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.draganddrop.DragAndDropEvent
+import androidx.compose.ui.draganddrop.DragAndDropTarget
+import androidx.compose.ui.draganddrop.DragAndDropTransferData
+import androidx.compose.ui.draganddrop.toAndroidDragEvent
+import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.rememberTextMeasurer
 import com.eried.eucplanet.ui.theme.AccentOrange
@@ -86,15 +151,22 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
@@ -122,12 +194,16 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.layout.onGloballyPositioned
 import kotlinx.coroutines.launch
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -137,7 +213,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.eried.eucplanet.R
-import com.eried.eucplanet.data.model.FlicAction
 import com.eried.eucplanet.data.sync.SyncChoice
 import com.eried.eucplanet.service.VoiceOption
 import com.eried.eucplanet.ui.common.HintText
@@ -145,7 +220,11 @@ import com.eried.eucplanet.ui.common.InfoHint
 import com.eried.eucplanet.ui.common.LocalSettingsSearchQuery
 import com.eried.eucplanet.ui.common.highlightMatches
 import com.eried.eucplanet.ui.theme.AccentBlue
+import com.eried.eucplanet.ui.theme.AccentGreen
+import com.eried.eucplanet.ui.theme.AccentPink
+import com.eried.eucplanet.ui.theme.AccentPurple
 import com.eried.eucplanet.ui.theme.AccentRed
+import com.eried.eucplanet.ui.theme.AccentYellow
 import com.eried.eucplanet.util.Units
 import sh.calvin.reorderable.ReorderableColumn
 
@@ -331,6 +410,7 @@ fun SettingsScreen(
     val titleWatch = stringResource(R.string.tab_watch)
     val titleNavigator = stringResource(R.string.nav_setting_params)
     val titleGpsSensors = stringResource(R.string.section_external_gps)
+    val titleDashboard = stringResource(R.string.tab_dashboard)
 
     val corpusGeneral = listOf(
         titleGeneral,
@@ -342,6 +422,26 @@ fun SettingsScreen(
         stringResource(R.string.auto_connect_on_start),
         stringResource(R.string.section_application),
         stringResource(R.string.back_button_action)
+    ).joinToString(" ")
+
+    val corpusDashboard = listOf(
+        titleDashboard,
+        stringResource(R.string.dashboard_section_metrics),
+        stringResource(R.string.dashboard_section_actions),
+        stringResource(R.string.dashboard_columns),
+        stringResource(R.string.dashboard_rolling_window),
+        stringResource(R.string.metric_chip_battery),
+        stringResource(R.string.metric_chip_temperature),
+        stringResource(R.string.metric_chip_voltage),
+        stringResource(R.string.metric_chip_current),
+        stringResource(R.string.metric_chip_load),
+        stringResource(R.string.metric_chip_trip),
+        stringResource(R.string.action_chip_horn),
+        stringResource(R.string.action_chip_light),
+        stringResource(R.string.action_chip_voice),
+        stringResource(R.string.action_chip_safety),
+        stringResource(R.string.action_chip_lock),
+        stringResource(R.string.action_chip_record)
     ).joinToString(" ")
 
     val corpusDisplay = listOf(
@@ -460,6 +560,9 @@ fun SettingsScreen(
     val sections: List<SectionDef> = listOf(
         SectionDef("general", titleGeneral, Icons.Default.Tune, corpusGeneral) {
             GeneralTab(settings, viewModel)
+        },
+        SectionDef("dashboard", titleDashboard, Icons.Default.Dashboard, corpusDashboard) {
+            DashboardLayoutTab(settings, viewModel)
         },
         SectionDef("display", titleDisplay, Icons.Default.DisplaySettings, corpusDisplay) {
             DisplayTab(settings, viewModel)
@@ -833,6 +936,3665 @@ private fun GeneralTab(
         HintText(stringResource(R.string.back_button_action_desc), small = true)
 
     }
+}
+
+// --- Dashboard Layout Tab ---
+//
+// Editor mirrors the live dashboard's look: the active slots render as a mini
+// version of the real StatCard / action-button grids, the rest of the catalog
+// shows up as draggable pills below. Long-press a tile or pill to drag, drop
+// on another tile to swap. Tap a tile to open the per-slot editor sheet (just
+// a reset-to-default button in this pass; corner-stat configuration lands
+// next). The configured order persists; wiring the live DashboardScreen to
+// read from it is the next phase.
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DashboardLayoutTab(
+    settings: com.eried.eucplanet.data.model.AppSettings,
+    viewModel: SettingsViewModel
+) {
+    val metricOrderRaw = viewModel.dashboardMetricOrder(settings)
+    val actionOrderRaw = viewModel.dashboardActionOrder(settings)
+
+    // Column count is no longer user-configurable: it mirrors the live
+    // dashboard's form-factor rules so the editor always shows the rider's
+    // actual layout. Phone keeps the classic 2×3 metrics + 3×2 actions;
+    // tablets/foldables (≥600dp width) bump to 3×2 metrics + 4×... but we
+    // keep the active count at 6 so the rider picks the same number of
+    // tiles regardless of device. The dashboardMetricsColumns /
+    // dashboardActionsColumns AppSettings fields are kept for forward
+    // compatibility but unused here.
+    val isWideScreen = LocalConfiguration.current.screenWidthDp >= 600
+    // Tablets always render the Wide (3-column) metrics layout, overriding the
+    // rider's per-account preference. On phones the View combo picks 2 (Default)
+    // or 3 (Wide) columns; `dashboardMetricsColumns` stores the user's choice
+    // verbatim so it round-trips when the rider switches devices.
+    val metricColumnsEffective = if (isWideScreen) 3 else settings.dashboardMetricsColumns.coerceIn(2, 3)
+    val actionColumnsEffective = 3
+    val metricActiveCount = 6
+    val actionActiveCount = 6
+
+    // Per-slot bottom sheet: holds the metric/action key being edited and the
+    // group it belongs to so the reset action targets the right list.
+    var editing by remember { mutableStateOf<DashboardEditTarget?>(null) }
+
+    // Tapping a tile in the Available (pool) region is informational only:
+    // riders must drag the tile onto a slot above to use it. A short toast
+    // explains the gesture instead of opening the edit sheet, which would
+    // be misleading (pool-position settings are not what they're editing).
+    // Throttled to one toast per 5 taps so it doesn't spam the rider while
+    // they explore — the same counter governs +STACK / +TEXT / +group
+    // template taps too.
+    val poolTapContext = LocalContext.current
+    val poolTapMessage = stringResource(R.string.dashboard_pool_tap_toast)
+    var poolTapCount by remember { mutableStateOf(0) }
+    val showPoolTapToast: () -> Unit = {
+        poolTapCount += 1
+        if (poolTapCount % 5 == 1) {
+            Toast.makeText(poolTapContext, poolTapMessage, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    // Custom drag system: the controller tracks the pointer in window
+    // coordinates and the registered drop targets, so the floating preview can
+    // animate its size, alpha and position live as the rider drags.
+    val dragController = remember { DashboardDragController() }
+    val poolAlpha by animateFloatAsState(
+        targetValue = if (dragController.isDragging) 0.4f else 1f,
+        label = "pool-alpha"
+    )
+
+    // Editor root's window-coordinate position is captured here so the
+    // floating preview can convert the controller's window-space pointer to
+    // a local offset relative to this Box and stay in the editor's own
+    // composition tree (rather than a Popup window, which would steal touch
+    // events from the drag source).
+    var editorRootInWindow by remember { mutableStateOf(Offset.Zero) }
+
+    // Order rendered to the grid stays equal to the persisted order during a
+    // drag: changing it mid-gesture caused the dragged tile to be relaid out
+    // under the rider's finger, which shifted the pointerInput's local frame
+    // and produced spurious drag deltas (the drag would "lurch" or get cut
+    // off). The make-space feel is now communicated via a slot highlight in
+    // the destination tile + the animateBounds slide on drop.
+    val metricOrder = metricOrderRaw
+    val actionOrder = actionOrderRaw
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .onGloballyPositioned { editorRootInWindow = it.positionInWindow() }
+    ) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        // --- Metrics ------------------------------------------------------
+        SectionHeader(stringResource(R.string.dashboard_section_metrics))
+
+        // Two-column row: layout choice (Default/Wide) on the left, the
+        // rolling-stats window on the right. Both affect metric rendering so
+        // they share a single visual band above the grid. The grid hint
+        // ("Long-press to drag…") goes under this row so the riders see the
+        // dropdowns first and the interaction hint right above the grid.
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            ViewDropdown(
+                modifier = Modifier.weight(1f),
+                columns = settings.dashboardMetricsColumns.coerceIn(2, 3),
+                forcedWide = isWideScreen,
+                onSelect = { viewModel.updateDashboardMetricsColumns(it) }
+            )
+            RollingWindowDropdown(
+                modifier = Modifier.weight(1f),
+                valueSeconds = settings.dashboardRollingWindowSeconds,
+                onSelect = { viewModel.updateDashboardRollingWindowSeconds(it) }
+            )
+        }
+        HintText(stringResource(R.string.dashboard_grid_hint), small = true)
+
+        MetricMiniGrid(
+            order = metricOrder,
+            activeCount = metricActiveCount,
+            columns = metricColumnsEffective,
+            valueOf = { key -> metricPlaceholderValue(key, settings) },
+            statsOf = { key -> viewModel.dashboardMetricSlotStats(settings, key) },
+            compositeOf = { id -> viewModel.getCompositeMetric(settings, id) },
+            customTileOf = { id -> viewModel.getCustomTile(settings, id) },
+            onSwapInto = { key, index ->
+                // Catalog model: grid sources SWAP (preserves both tiles),
+                // pool sources COPY (catalog stays full, slot gets the new
+                // metric, displaced tile is discarded). Templates always
+                // spawn a fresh dynamic instance regardless of source.
+                when {
+                    key == COMPOSITE_TEMPLATE_KEY -> viewModel.createCompositeMetricAt(index)
+                    key == CUSTOM_TILE_TEMPLATE_KEY -> viewModel.createCustomTileAt(index)
+                    dragController.sourceFromGrid -> viewModel.moveDashboardMetricToIndex(key, index)
+                    else -> viewModel.setDashboardMetricAtIndex(key, index)
+                }
+            },
+            onTapTile = { key, slotIndex ->
+                editing = when {
+                    isCompositeMetricKey(key) -> DashboardEditTarget.Composite(key, slotIndex)
+                    isCustomTileKey(key) -> DashboardEditTarget.CustomTile(key, slotIndex)
+                    else -> DashboardEditTarget.Metric(key, slotIndex)
+                }
+            },
+            controller = dragController
+        )
+
+        Spacer(Modifier.height(4.dp))
+        Column(modifier = Modifier.alpha(poolAlpha)) {
+            Text(
+                stringResource(R.string.dashboard_pool_metrics),
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            MetricPool(
+                catalogKeys = viewModel.knownDashboardMetrics,
+                valueOf = { key -> metricPlaceholderValue(key, settings) },
+                statsEnabledOf = { key ->
+                    val s = viewModel.dashboardMetricSlotStats(settings, key)
+                    s.left != DashboardStat.NONE || s.right != DashboardStat.NONE || s.sparkline
+                },
+                onTap = { _ -> showPoolTapToast() },
+                onDeleteComposite = { id -> viewModel.deleteCompositeMetric(id) },
+                onDeleteCustomTile = { id -> viewModel.deleteCustomTile(id) },
+                onDemoteMetric = { key -> viewModel.demoteMetricToCustomTile(key) },
+                controller = dragController
+            )
+        }
+
+        // --- Action buttons ----------------------------------------------
+        SectionHeader(stringResource(R.string.dashboard_section_actions))
+        HintText(stringResource(R.string.dashboard_grid_hint), small = true)
+
+        ActionMiniGrid(
+            order = actionOrder,
+            activeCount = actionActiveCount,
+            columns = actionColumnsEffective,
+            groupOf = { id -> viewModel.getActionGroup(settings, id) },
+            onSwapInto = { key, index ->
+                // Catalog model — see metric grid for explanation.
+                when {
+                    key == ACTION_GROUP_TEMPLATE_KEY -> viewModel.createActionGroupAt(index)
+                    dragController.sourceFromGrid -> viewModel.moveDashboardActionToIndex(key, index)
+                    else -> viewModel.setDashboardActionAtIndex(key, index)
+                }
+            },
+            onTapTile = { key, slotIndex ->
+                editing = if (isActionGroupKey(key)) DashboardEditTarget.Group(key, slotIndex)
+                else DashboardEditTarget.Action(key, slotIndex)
+            },
+            controller = dragController
+        )
+
+        Spacer(Modifier.height(4.dp))
+        Column(modifier = Modifier.alpha(poolAlpha)) {
+            Text(
+                stringResource(R.string.dashboard_pool_actions),
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            ActionPool(
+                catalogKeys = viewModel.knownDashboardActions,
+                onTap = { _ -> showPoolTapToast() },
+                onDeleteGroup = { id -> viewModel.deleteActionGroup(id) },
+                controller = dragController
+            )
+        }
+    }
+        // Floating drag preview rendered as a sibling of the Column inside
+        // the editor's root Box. Stays in the same Compose hit-test tree as
+        // the source so the drag's pointerInput keeps receiving moves.
+        DashboardDragPreviewOverlay(
+            controller = dragController,
+            rootInWindow = editorRootInWindow,
+            renderMetric = { key, value ->
+                MetricDragPreview(key = key, value = value, settings = settings, viewModel = viewModel)
+            },
+            renderAction = { key ->
+                ActionDragPreview(key = key, settings = settings, viewModel = viewModel)
+            }
+        )
+    } // end editor root Box
+
+    editing?.let { target ->
+        // All five sheet kinds share the same "restore this slot to its
+        // shipped default" semantic. The VM reset path handles deleting
+        // any dynamic instance (composite / custom tile / group) that
+        // happens to occupy the slot AND wiping the natural key's stats
+        // so the restored metric shows its fresh out-of-box appearance.
+        val onResetSlot: () -> Unit = {
+            val isActionTarget = target is DashboardEditTarget.Action ||
+                target is DashboardEditTarget.Group
+            if (isActionTarget) {
+                viewModel.resetDashboardActionAtIndex(target.slotIndex)
+            } else {
+                viewModel.resetDashboardMetricAtIndex(target.slotIndex)
+            }
+            editing = null
+        }
+        when (target) {
+            is DashboardEditTarget.Composite -> CompositeMetricSheet(
+                id = target.key,
+                settings = settings,
+                viewModel = viewModel,
+                onDismiss = { editing = null },
+                onReset = onResetSlot
+            )
+            is DashboardEditTarget.Group -> ActionGroupSheet(
+                id = target.key,
+                settings = settings,
+                viewModel = viewModel,
+                onDismiss = { editing = null },
+                onReset = onResetSlot
+            )
+            is DashboardEditTarget.CustomTile -> CustomTileSheet(
+                id = target.key,
+                settings = settings,
+                viewModel = viewModel,
+                onDismiss = { editing = null },
+                onReset = onResetSlot
+            )
+            else -> DashboardSlotSheet(
+                target = target,
+                settings = settings,
+                viewModel = viewModel,
+                onDismiss = { editing = null },
+                onReset = onResetSlot
+            )
+        }
+    }
+}
+
+// Visual-only renderers used by DashboardDragPreviewOverlay. They mirror the
+// MetricTile / ActionTile content but skip the drag, drop and click wiring so
+// they can be rendered inside the floating Popup without re-entering the drag
+// state machine.
+
+@Composable
+private fun MetricDragPreview(
+    key: String,
+    value: String,
+    settings: com.eried.eucplanet.data.model.AppSettings,
+    viewModel: SettingsViewModel
+) {
+    // Composite + custom-tile instances (and their templates) render through
+    // this preview path too so the dragged tile looks like what it will
+    // become once the rider drops it. For templates we substitute a default
+    // placeholder instance so the rider sees a representative preview.
+    if (isCompositeMetricKey(key) || key == COMPOSITE_TEMPLATE_KEY) {
+        val composite = if (key == COMPOSITE_TEMPLATE_KEY) MetricComposite()
+        else viewModel.getCompositeMetric(settings, key) ?: MetricComposite()
+        val surfaceColor = MaterialTheme.colorScheme.surfaceVariant
+        val outlineColor = MaterialTheme.colorScheme.outlineVariant
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .clip(RoundedCornerShape(10.dp))
+                .background(surfaceColor)
+                .border(1.dp, outlineColor, RoundedCornerShape(10.dp))
+        ) {
+            CompositeMetricBody(
+                composite = composite,
+                valueOf = { k -> metricPlaceholderValue(k, settings) }
+            )
+        }
+        return
+    }
+    if (isCustomTileKey(key) || key == CUSTOM_TILE_TEMPLATE_KEY) {
+        val tile = if (key == CUSTOM_TILE_TEMPLATE_KEY) CustomTile()
+        else viewModel.getCustomTile(settings, key) ?: CustomTile()
+        val surfaceColor = MaterialTheme.colorScheme.surfaceVariant
+        val outlineColor = MaterialTheme.colorScheme.outlineVariant
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .clip(RoundedCornerShape(10.dp))
+                .background(surfaceColor)
+                .border(1.dp, outlineColor, RoundedCornerShape(10.dp))
+        ) {
+            CustomTileBody(tile = tile)
+        }
+        return
+    }
+    val accent = metricAccentColor(key)
+    val label = metricChipLabel(key)
+    val surfaceColor = MaterialTheme.colorScheme.surfaceVariant
+    val outlineColor = MaterialTheme.colorScheme.outlineVariant
+    val stats = viewModel.dashboardMetricSlotStats(settings, key)
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .clip(RoundedCornerShape(10.dp))
+            .background(surfaceColor)
+            .border(1.dp, outlineColor, RoundedCornerShape(10.dp))
+    ) {
+        if (stats.sparkline) {
+            WavePatternBackground(accent = accent)
+        }
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 6.dp, vertical = 6.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            ThreeZoneRow(
+                metricLabel = label,
+                stats = stats,
+                value = value,
+                accent = accent,
+                centerBigSp = 14,
+                sideValueSp = 10,
+                sideLabelSp = 9,
+                metricLabelSp = 9
+            )
+        }
+    }
+}
+
+@Composable
+private fun ActionDragPreview(
+    key: String,
+    settings: com.eried.eucplanet.data.model.AppSettings,
+    viewModel: SettingsViewModel
+) {
+    // Group instance + template render through this preview too, with the
+    // accent-tinted folder icon so the floating preview reads as "you're
+    // moving a group" rather than a plain action.
+    val isGroup = isActionGroupKey(key) || key == ACTION_GROUP_TEMPLATE_KEY
+    val groupIconKey = if (isGroup) {
+        if (key == ACTION_GROUP_TEMPLATE_KEY) GROUP_DEFAULT_ICON
+        else viewModel.getActionGroup(settings, key)?.icon ?: GROUP_DEFAULT_ICON
+    } else null
+    val groupLabel = if (isGroup) {
+        if (key == ACTION_GROUP_TEMPLATE_KEY) stringResource(R.string.dashboard_group_default_name)
+        else viewModel.getActionGroup(settings, key)?.name?.ifBlank { null }
+            ?: stringResource(R.string.dashboard_group_default_name)
+    } else null
+    val icon = if (isGroup) groupIconFor(groupIconKey!!) else dashboardActionIcon(key)
+    val label = if (isGroup) groupLabel!! else actionChipLabel(key)
+    val tint = if (isGroup) MaterialTheme.colorScheme.primary
+        else MaterialTheme.colorScheme.onSurfaceVariant
+    val surfaceColor = MaterialTheme.colorScheme.surfaceVariant
+    val outlineColor = MaterialTheme.colorScheme.outlineVariant
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .clip(RoundedCornerShape(10.dp))
+            .background(surfaceColor)
+            .border(1.dp, outlineColor, RoundedCornerShape(10.dp))
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(6.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            if (icon != null) {
+                Icon(
+                    icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp),
+                    tint = tint
+                )
+                Spacer(Modifier.height(4.dp))
+            }
+            Text(
+                label,
+                fontSize = 11.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}
+
+private sealed interface DashboardEditTarget {
+    val key: String
+    /** Slot index in the active grid; Reset uses this to restore the shipped occupant. */
+    val slotIndex: Int
+    data class Metric(override val key: String, override val slotIndex: Int) : DashboardEditTarget
+    data class Action(override val key: String, override val slotIndex: Int) : DashboardEditTarget
+    /** Composite metric instance — `key` is the composite ID like `M:abc123`. */
+    data class Composite(override val key: String, override val slotIndex: Int) : DashboardEditTarget
+    /** Action group instance — `key` is the group ID like `G:abc123`. */
+    data class Group(override val key: String, override val slotIndex: Int) : DashboardEditTarget
+    /** Custom tile instance — `key` is the tile ID like `C:abc123`. */
+    data class CustomTile(override val key: String, override val slotIndex: Int) : DashboardEditTarget
+}
+
+private const val DASHBOARD_DRAG_METRIC_LABEL = "eucplanet/dashMetric"
+private const val DASHBOARD_DRAG_ACTION_LABEL = "eucplanet/dashAction"
+
+// ---- Section helpers ---------------------------------------------------
+
+@Composable
+private fun DashboardColumnSelector(current: Int, onSelect: (Int) -> Unit) {
+    val options = listOf(2, 3, 4)
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            stringResource(R.string.dashboard_columns),
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.padding(end = 12.dp)
+        )
+        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+            options.forEachIndexed { index, n ->
+                SegmentedButton(
+                    selected = n == current,
+                    onClick = { onSelect(n) },
+                    shape = SegmentedButtonDefaults.itemShape(index, options.size)
+                ) { Text(n.toString()) }
+            }
+        }
+    }
+}
+
+
+// ---- Metric grid -------------------------------------------------------
+//
+// Rendered as a Column of Rows so the layout stays in one piece for drag
+// detection (LazyVerticalGrid swallows the drag-and-drop modifiers).
+
+// Custom bounds transform applied to every grid tile so column-count changes
+// (2 ↔ 3 ↔ 4) animate visibly. The default BoundsTransform settles too
+// quickly for small motion deltas — tiles that move only a few dp appear to
+// snap. This spring is slower (Spring.StiffnessLow) and slightly underdamped
+// (0.7) so motion reads as a smooth glide for both big and small repositions.
+@OptIn(androidx.compose.animation.ExperimentalSharedTransitionApi::class)
+private val dashboardTileBoundsTransform = androidx.compose.animation.BoundsTransform { _, _ ->
+    androidx.compose.animation.core.spring(
+        stiffness = androidx.compose.animation.core.Spring.StiffnessLow,
+        dampingRatio = 0.75f
+    )
+}
+
+@OptIn(androidx.compose.animation.ExperimentalSharedTransitionApi::class)
+@Composable
+private fun MetricMiniGrid(
+    order: List<String>,
+    activeCount: Int,
+    columns: Int,
+    valueOf: (String) -> String,
+    statsOf: (String) -> MetricSlotStats,
+    compositeOf: (String) -> MetricComposite?,
+    customTileOf: (String) -> CustomTile?,
+    onSwapInto: (String, Int) -> Unit,
+    onTapTile: (String, Int) -> Unit,
+    controller: DashboardDragController
+) {
+    val active = order.take(activeCount)
+    val rows = (active.size + columns - 1) / columns
+    // LookaheadScope + animateBounds: when the rider drops a swap the
+    // displaced tile glides to its new slot instead of teleporting.
+    androidx.compose.ui.layout.LookaheadScope {
+        val lookahead = this
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            for (rowIdx in 0 until rows) {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    for (colIdx in 0 until columns) {
+                        val slotIndex = rowIdx * columns + colIdx
+                        val key = active.getOrNull(slotIndex)
+                        if (key != null) {
+                            androidx.compose.runtime.key(key) {
+                                val tileModifier = Modifier
+                                    .weight(1f)
+                                    .height(74.dp)
+                                    .animateBounds(
+                                        lookaheadScope = lookahead,
+                                        boundsTransform = dashboardTileBoundsTransform
+                                    )
+                                when {
+                                    isCompositeMetricKey(key) -> {
+                                        val composite = compositeOf(key) ?: MetricComposite()
+                                        CompositeMetricTile(
+                                            id = key,
+                                            composite = composite,
+                                            slotIndex = slotIndex,
+                                            valueOf = valueOf,
+                                            modifier = tileModifier,
+                                            onTap = { onTapTile(key, slotIndex) },
+                                            onSwapInto = onSwapInto,
+                                            controller = controller
+                                        )
+                                    }
+                                    isCustomTileKey(key) -> {
+                                        val tile = customTileOf(key) ?: CustomTile()
+                                        CustomTileView(
+                                            id = key,
+                                            tile = tile,
+                                            slotIndex = slotIndex,
+                                            modifier = tileModifier,
+                                            onTap = { onTapTile(key, slotIndex) },
+                                            onSwapInto = onSwapInto,
+                                            controller = controller
+                                        )
+                                    }
+                                    else -> {
+                                        MetricTile(
+                                            key = key,
+                                            value = valueOf(key),
+                                            stats = statsOf(key),
+                                            slotIndex = slotIndex,
+                                            modifier = tileModifier,
+                                            onTap = { onTapTile(key, slotIndex) },
+                                            onSwapInto = onSwapInto,
+                                            controller = controller
+                                        )
+                                    }
+                                }
+                            }
+                        } else {
+                            Box(modifier = Modifier.weight(1f))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Composite metric tile — one grid slot rendering 2 or 3 sub-metric current
+ * values in the chosen layout. Wraps the same drag/drop modifiers as
+ * [MetricTile] so the rider can re-position the composite or replace it
+ * with another tile.
+ */
+@OptIn(androidx.compose.animation.ExperimentalSharedTransitionApi::class)
+@Composable
+private fun CompositeMetricTile(
+    id: String,
+    composite: MetricComposite,
+    slotIndex: Int,
+    valueOf: (String) -> String,
+    modifier: Modifier,
+    onTap: () -> Unit,
+    onSwapInto: (String, Int) -> Unit,
+    controller: DashboardDragController
+) {
+    val surfaceColor = MaterialTheme.colorScheme.surfaceVariant
+    val outlineColor = MaterialTheme.colorScheme.outlineVariant
+    val isBeingDragged = controller.draggingKey == id
+    val isDropTarget = controller.isDragging &&
+        controller.draggingKey != id &&
+        controller.hoveredTarget?.slotIndex == slotIndex &&
+        controller.sourceKind == DragSourceKind.METRIC
+    // Accent for the highlight border picks the first cell's color so the
+    // composite reads as "the rider's chosen stack" rather than a generic
+    // neutral container.
+    val firstCellAccent = composite.cells.firstOrNull()?.let { metricAccentColor(it) }
+        ?: MaterialTheme.colorScheme.primary
+    val borderColor by androidx.compose.animation.animateColorAsState(
+        targetValue = if (isDropTarget) firstCellAccent else outlineColor,
+        label = "composite-tile-border"
+    )
+    val borderWidth by androidx.compose.animation.core.animateDpAsState(
+        targetValue = if (isDropTarget) 2.dp else 1.dp,
+        label = "composite-tile-border-w"
+    )
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(10.dp))
+            .background(surfaceColor)
+            .border(borderWidth, borderColor, RoundedCornerShape(10.dp))
+            .clickable(onClick = onTap)
+            .dashboardDragSource(
+                key = id,
+                value = "",
+                sourceKind = DragSourceKind.METRIC,
+                controller = controller,
+                fromGrid = true
+            )
+            .dashboardDropTarget(
+                key = "metric-slot-$slotIndex",
+                kind = DropKind.METRIC_GRID_SLOT,
+                slotIndex = slotIndex,
+                controller = controller,
+                onDrop = { sourceKey -> onSwapInto(sourceKey, slotIndex) }
+            )
+    ) {
+        Box(modifier = Modifier.fillMaxSize().alpha(if (isBeingDragged) 0f else 1f)) {
+            CompositeMetricBody(composite = composite, valueOf = valueOf)
+        }
+    }
+}
+
+/**
+ * Inner layout switcher for a composite tile. Each layout renders its cells
+ * with a per-cell accent + uppercase short label; no stats, no sparkline.
+ * Public-internal so the live dashboard renderer can reuse the exact same
+ * body — the editor passes placeholder values, the live dashboard passes
+ * real telemetry, both go through this composable.
+ */
+@Composable
+fun CompositeMetricBody(
+    composite: MetricComposite,
+    valueOf: (String) -> String
+) {
+    val cells = composite.cells.take(composite.layout.cellCount)
+    val padded = cells + List(composite.layout.cellCount - cells.size) { "" }
+    // Parallel stats list, padded with CURRENT for missing entries so
+    // every cell has a defined stat. CURRENT means "no stat indicator"
+    // — the cell shows the metric label + value as before.
+    val paddedStats = composite.cellStats.take(composite.layout.cellCount) +
+        List(
+            (composite.layout.cellCount - composite.cellStats.size).coerceAtLeast(0)
+        ) { DashboardStat.CURRENT }
+    val divider = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+    when (composite.layout) {
+        CompositeLayout.ROW2 -> Column(
+            modifier = Modifier.fillMaxSize().padding(horizontal = 2.dp, vertical = 4.dp)
+        ) {
+            CompositeCellRow(padded[0], paddedStats[0], valueOf, Modifier.fillMaxWidth().weight(1f))
+            Box(modifier = Modifier.fillMaxWidth().height(1.dp).background(divider))
+            CompositeCellRow(padded[1], paddedStats[1], valueOf, Modifier.fillMaxWidth().weight(1f))
+        }
+        CompositeLayout.COL2 -> Row(
+            modifier = Modifier.fillMaxSize().padding(horizontal = 4.dp, vertical = 6.dp)
+        ) {
+            CompositeCell(padded[0], paddedStats[0], valueOf, Modifier.weight(1f))
+            Box(modifier = Modifier.fillMaxHeight().width(1.dp).background(divider))
+            CompositeCell(padded[1], paddedStats[1], valueOf, Modifier.weight(1f))
+        }
+        CompositeLayout.COL3 -> Row(
+            modifier = Modifier.fillMaxSize().padding(horizontal = 4.dp, vertical = 6.dp)
+        ) {
+            CompositeCell(padded[0], paddedStats[0], valueOf, Modifier.weight(1f))
+            Box(modifier = Modifier.fillMaxHeight().width(1.dp).background(divider))
+            CompositeCell(padded[1], paddedStats[1], valueOf, Modifier.weight(1f))
+            Box(modifier = Modifier.fillMaxHeight().width(1.dp).background(divider))
+            CompositeCell(padded[2], paddedStats[2], valueOf, Modifier.weight(1f))
+        }
+    }
+}
+
+@Composable
+private fun CompositeCell(
+    key: String,
+    stat: DashboardStat,
+    valueOf: (String) -> String,
+    modifier: Modifier = Modifier
+) {
+    val isEmpty = key.isEmpty() || key == COMPOSITE_CELL_EMPTY
+    val accent = if (!isEmpty) metricAccentColor(key) else MaterialTheme.colorScheme.onSurfaceVariant
+    if (isEmpty) {
+        // Column-style cells live in COL2/COL3 layouts where horizontal space
+        // is tight (especially three side-by-side cells), so an "(empty)"
+        // word reads as crowded clutter. A single en-dash glyph is enough to
+        // signal "deliberately blank" without competing with the surrounding
+        // cells for attention.
+        Box(
+            modifier = modifier,
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                "–",
+                fontSize = 16.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                maxLines = 1
+            )
+        }
+        return
+    }
+    val label = metricChipLabel(key).uppercase()
+    val value = valueOf(key)
+    // Stat indicator on top — only shown when the rider picked a non-
+    // default stat (Min / Max / Avg / Median / P75 / etc.). Tinted with
+    // the metric's accent so the cell reads as "MAX of SPEED" at a
+    // glance rather than the value alone being ambiguous.
+    val showStat = stat != DashboardStat.CURRENT && stat != DashboardStat.NONE
+    Box(
+        modifier = modifier.fillMaxHeight(),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            if (showStat) {
+                Text(
+                    statShortLabel(stat),
+                    fontSize = 7.sp,
+                    color = accent.copy(alpha = 0.85f),
+                    fontWeight = FontWeight.Bold,
+                    letterSpacing = 0.5.sp,
+                    maxLines = 1
+                )
+            }
+            Text(
+                label,
+                fontSize = 8.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontWeight = FontWeight.Medium,
+                letterSpacing = 0.5.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                value,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Bold,
+                color = accent,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}
+
+/**
+ * ROW2 layout cell — label LEFT, value RIGHT. The 2-row composite is wide
+ * and short, so stacking label-above-value (the column form) wastes the
+ * horizontal space. Putting them side-by-side reads more like a row in a
+ * spec sheet ("SPEED   42 km/h"), which is what the rider asked for.
+ */
+@Composable
+private fun CompositeCellRow(
+    key: String,
+    stat: DashboardStat,
+    valueOf: (String) -> String,
+    modifier: Modifier = Modifier
+) {
+    val isEmpty = key.isEmpty() || key == COMPOSITE_CELL_EMPTY
+    if (isEmpty) {
+        Box(
+            modifier = modifier.padding(horizontal = 8.dp),
+            contentAlignment = Alignment.CenterStart
+        ) {
+            Text(
+                stringResource(R.string.dashboard_composite_empty_label),
+                fontSize = 10.sp,
+                fontStyle = androidx.compose.ui.text.font.FontStyle.Italic,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+        return
+    }
+    val accent = metricAccentColor(key)
+    val label = metricChipLabel(key).uppercase()
+    val value = valueOf(key)
+    val showStat = stat != DashboardStat.CURRENT && stat != DashboardStat.NONE
+    // Label gets the squeezable slot (weight 1f, fill = true) so it expands to
+    // hold the leftover space after the value's natural width — that pins the
+    // value flush right while still ellipsising the label if it grows too long.
+    // Stat indicator (when present) sits as a small label INLINE with the
+    // metric label, separated by a · so the row reads as "MAX · SPEED  42".
+    Row(
+        modifier = modifier.padding(horizontal = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (showStat) {
+            Text(
+                statShortLabel(stat),
+                fontSize = 8.sp,
+                color = accent.copy(alpha = 0.85f),
+                fontWeight = FontWeight.Bold,
+                letterSpacing = 0.5.sp,
+                maxLines = 1
+            )
+            Spacer(Modifier.width(4.dp))
+        }
+        Text(
+            label,
+            fontSize = 9.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontWeight = FontWeight.Medium,
+            letterSpacing = 0.5.sp,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f)
+        )
+        Text(
+            value,
+            fontSize = 13.sp,
+            fontWeight = FontWeight.Bold,
+            color = accent,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+@Composable
+private fun MetricTile(
+    key: String,
+    value: String,
+    stats: MetricSlotStats,
+    slotIndex: Int,
+    modifier: Modifier,
+    onSwapInto: (String, Int) -> Unit,
+    onTap: () -> Unit,
+    controller: DashboardDragController
+) {
+    val accent = metricAccentColor(key)
+    val label = metricChipLabel(key)
+    val surfaceColor = MaterialTheme.colorScheme.surfaceVariant
+    val outlineColor = MaterialTheme.colorScheme.outlineVariant
+    val hasSideReadings = !stats.isDefault
+    val isBeingDragged = controller.draggingKey == key
+    // Animated border when this slot is the drag's drop target — gives the
+    // rider visual feedback for "release here" without the recomposition
+    // glitches that mid-drag layout shifts caused.
+    val isDropTarget = controller.isDragging &&
+        controller.draggingKey != key &&
+        controller.hoveredTarget?.slotIndex == slotIndex &&
+        controller.sourceKind == DragSourceKind.METRIC
+    val borderColor by androidx.compose.animation.animateColorAsState(
+        targetValue = if (isDropTarget) accent else outlineColor,
+        label = "metric-tile-border"
+    )
+    val borderWidth by androidx.compose.animation.core.animateDpAsState(
+        targetValue = if (isDropTarget) 2.dp else 1.dp,
+        label = "metric-tile-border-w"
+    )
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(10.dp))
+            .background(surfaceColor)
+            .border(borderWidth, borderColor, RoundedCornerShape(10.dp))
+            .clickable(onClick = onTap)
+            .dashboardDragSource(
+                key = key,
+                value = value,
+                sourceKind = DragSourceKind.METRIC,
+                controller = controller,
+                fromGrid = true
+            )
+            .dashboardDropTarget(
+                key = "metric-slot-$slotIndex",
+                kind = DropKind.METRIC_GRID_SLOT,
+                slotIndex = slotIndex,
+                controller = controller,
+                onDrop = { sourceKey -> onSwapInto(sourceKey, slotIndex) }
+            )
+    ) {
+        // Drag state hides only the content — the border + surface stay so
+        // the slot reads as a clearly-marked empty placeholder for the tile
+        // the rider is holding.
+        Box(modifier = Modifier.fillMaxSize().alpha(if (isBeingDragged) 0f else 1f)) {
+            if (stats.sparkline) {
+                WavePatternBackground(accent = accent)
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 6.dp, vertical = 6.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                ThreeZoneRow(
+                    metricLabel = label,
+                    stats = stats,
+                    value = value,
+                    accent = accent,
+                    centerBigSp = if (hasSideReadings) 13 else 16,
+                    sideValueSp = 10,
+                    sideLabelSp = 9,
+                    metricLabelSp = 9
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Pool = catalog. Renders the metric template followed by every key in
+ * [catalogKeys] sorted alphabetically by its display label. Composite and
+ * custom-tile instances are NOT shown here — they live only in the grid;
+ * the catalog is the rider's source-of-truth list of static metrics.
+ *
+ * Drop behaviour (only fires when the drag started on a big grid tile —
+ * pool→pool drags are intentional no-ops):
+ *   - Composite tile → delete its definition
+ *   - Custom tile   → delete its definition
+ *   - Static metric → demote (slot becomes empty custom tile; the static
+ *     metric stays in the catalog so the rider can re-drag it)
+ *
+ * @param catalogKeys static metric keys present in the catalog
+ * @see SettingsViewModel.knownDashboardMetrics for the catalog source
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun MetricPool(
+    catalogKeys: List<String>,
+    valueOf: (String) -> String,
+    statsEnabledOf: (String) -> Boolean,
+    onTap: (String) -> Unit,
+    onDeleteComposite: (String) -> Unit,
+    onDeleteCustomTile: (String) -> Unit,
+    onDemoteMetric: (String) -> Unit,
+    controller: DashboardDragController
+) {
+    // metricChipLabel is @Composable (reads string resources), so resolve
+    // labels first then sort. Stable .uppercase() avoids locale-flips
+    // between "Speed" and "SPEED" when adding a metric.
+    val labeled = catalogKeys.map { it to metricChipLabel(it) }
+    val sorted = labeled.sortedBy { it.second.uppercase() }.map { it.first }
+    // Pool pill physical size in pixels — needs to live inside the composable
+    // since LocalDensity is composition-scoped. Used as the "shrink-back" size
+    // when a previously-grown pool pill is dragged back over this region.
+    val density = LocalDensity.current
+    val poolPillSizePx = androidx.compose.runtime.remember(density) {
+        with(density) { androidx.compose.ui.unit.IntSize(102.dp.roundToPx(), 52.dp.roundToPx()) }
+    }
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            // Compact, scrollable pool: shows ~3.5 rows of pills so the half
+            // row peeking at the bottom hints that more content scrolls into
+            // view. Remaining pool items reveal via vertical scroll.
+            .heightIn(max = 210.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.4f))
+            .dashboardHintRegion(
+                key = "metric-pool",
+                sourceKind = DragSourceKind.METRIC,
+                expectedSizePx = poolPillSizePx,
+                controller = controller
+            )
+            // Pool handles three different "back to pool" actions in one
+            // drop target, distinguished by the source key:
+            //  - Composite tile → delete the composite definition
+            //  - Custom tile → delete the custom-tile definition
+            //  - Regular metric in active grid → demote: metric goes to the
+            //    pool, a fresh empty custom tile spawns in its place
+            // Template drags (COMPOSITE_TEMPLATE_KEY / CUSTOM_TILE_TEMPLATE_KEY)
+            // are rejected so dragging a template back here doesn't double-
+            // spawn anything. overrideExpectedSizePx shrinks the floating
+            // preview to pool-pill size on hover so the rider sees the
+            // "going back to pool" affordance regardless of which case fires.
+            .dashboardDropTarget(
+                key = "metric-pool-trash",
+                kind = DropKind.METRIC_POOL_TRASH,
+                controller = controller,
+                onDrop = { sourceKey ->
+                    // Only fire when the source was a big grid tile.
+                    // Pool→pool drags are no-ops (catalog stays full).
+                    if (controller.sourceFromGrid) {
+                        when {
+                            isCompositeMetricKey(sourceKey) -> onDeleteComposite(sourceKey)
+                            isCustomTileKey(sourceKey) -> onDeleteCustomTile(sourceKey)
+                            else -> onDemoteMetric(sourceKey)
+                        }
+                    }
+                },
+                acceptsSourceKey = { sourceKey ->
+                    sourceKey != COMPOSITE_TEMPLATE_KEY &&
+                        sourceKey != CUSTOM_TILE_TEMPLATE_KEY
+                },
+                overrideExpectedSizePx = poolPillSizePx
+            )
+            .verticalScroll(rememberScrollState())
+            .padding(8.dp)
+    ) {
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            // Composite template sits at the head of the pool as an always-
+            // available source. Dragging it onto a grid slot spawns a new
+            // composite instance.
+            MetricCompositeTemplatePill(controller = controller)
+            // CustomTileTemplatePill is intentionally hidden — riders create
+            // custom tiles implicitly by dragging a regular metric back to
+            // the pool. The template pill code is preserved so we can
+            // re-surface it later if we want explicit creation.
+            sorted.forEach { key ->
+                MetricPoolPill(
+                    key = key,
+                    value = valueOf(key),
+                    statsEnabled = statsEnabledOf(key),
+                    onTap = onTap,
+                    controller = controller
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MetricCompositeTemplatePill(
+    controller: DashboardDragController
+) {
+    val outlineColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f)
+    val labelColor = MaterialTheme.colorScheme.primary
+    val density = LocalDensity.current
+    val dashSpec = remember(density) {
+        androidx.compose.ui.graphics.drawscope.Stroke(
+            width = with(density) { 1.5.dp.toPx() },
+            pathEffect = androidx.compose.ui.graphics.PathEffect.dashPathEffect(
+                floatArrayOf(
+                    with(density) { 4.dp.toPx() },
+                    with(density) { 3.dp.toPx() }
+                )
+            )
+        )
+    }
+    val cornerRadiusPx = with(density) { 10.dp.toPx() }
+    val isBeingDragged = controller.draggingKey == COMPOSITE_TEMPLATE_KEY
+    Box(
+        modifier = Modifier
+            .width(102.dp)
+            .height(52.dp)
+            .drawBehind {
+                // Dashed rounded-rect outline drawn manually because Compose's
+                // `border` modifier doesn't accept a PathEffect for dashes.
+                drawRoundRect(
+                    color = outlineColor,
+                    cornerRadius = androidx.compose.ui.geometry.CornerRadius(cornerRadiusPx),
+                    style = dashSpec
+                )
+            }
+            // Templates use the metric drag-source so the controller treats
+            // them like a pool pill. The downstream drop callback distinguishes
+            // template key from a real key and routes to createCompositeMetricAt
+            // instead of moveDashboardMetricToIndex.
+            .dashboardDragSource(
+                key = COMPOSITE_TEMPLATE_KEY,
+                value = "",
+                sourceKind = DragSourceKind.METRIC,
+                controller = controller,
+                fromGrid = false
+            )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 6.dp, vertical = 4.dp)
+                .alpha(if (isBeingDragged) 0.4f else 1f),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Add,
+                contentDescription = null,
+                tint = labelColor,
+                modifier = Modifier.size(18.dp)
+            )
+            Text(
+                stringResource(R.string.dashboard_composite_template_label),
+                fontSize = 9.sp,
+                color = labelColor,
+                fontWeight = FontWeight.Medium,
+                letterSpacing = 0.5.sp,
+                maxLines = 1
+            )
+        }
+    }
+}
+
+/**
+ * Pool source pill for the rider's custom-text/URL/QR tile. Same dashed
+ * outline as the + STACK template so the two read as paired "drag me onto
+ * a slot to add a special tile" actions.
+ */
+@Composable
+private fun CustomTileTemplatePill(
+    controller: DashboardDragController
+) {
+    val outlineColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f)
+    val labelColor = MaterialTheme.colorScheme.primary
+    val density = LocalDensity.current
+    val dashSpec = remember(density) {
+        androidx.compose.ui.graphics.drawscope.Stroke(
+            width = with(density) { 1.5.dp.toPx() },
+            pathEffect = androidx.compose.ui.graphics.PathEffect.dashPathEffect(
+                floatArrayOf(
+                    with(density) { 4.dp.toPx() },
+                    with(density) { 3.dp.toPx() }
+                )
+            )
+        )
+    }
+    val cornerRadiusPx = with(density) { 10.dp.toPx() }
+    val isBeingDragged = controller.draggingKey == CUSTOM_TILE_TEMPLATE_KEY
+    Box(
+        modifier = Modifier
+            .width(102.dp)
+            .height(52.dp)
+            .drawBehind {
+                drawRoundRect(
+                    color = outlineColor,
+                    cornerRadius = androidx.compose.ui.geometry.CornerRadius(cornerRadiusPx),
+                    style = dashSpec
+                )
+            }
+            .dashboardDragSource(
+                key = CUSTOM_TILE_TEMPLATE_KEY,
+                value = "",
+                sourceKind = DragSourceKind.METRIC,
+                controller = controller,
+                fromGrid = false
+            )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 6.dp, vertical = 4.dp)
+                .alpha(if (isBeingDragged) 0.4f else 1f),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Add,
+                contentDescription = null,
+                tint = labelColor,
+                modifier = Modifier.size(18.dp)
+            )
+            Text(
+                stringResource(R.string.dashboard_custom_tile_template_label),
+                fontSize = 9.sp,
+                color = labelColor,
+                fontWeight = FontWeight.Medium,
+                letterSpacing = 0.5.sp,
+                maxLines = 1
+            )
+        }
+    }
+}
+
+/**
+ * Custom tile renderer for both grid slots and drag preview. Shows the
+ * rider's chosen icon and text. When the text is blank but a URL is set
+ * (OPEN_URL / SHOW_QR action), falls back to the URL's domain so the tile
+ * stays informative even before the rider types a label. A small action
+ * badge in the bottom-right marks the tap behaviour (link / QR) so a
+ * passenger can read the tile type at a glance.
+ */
+@OptIn(androidx.compose.animation.ExperimentalSharedTransitionApi::class)
+@Composable
+private fun CustomTileView(
+    id: String,
+    tile: CustomTile,
+    slotIndex: Int,
+    modifier: Modifier,
+    onTap: () -> Unit,
+    onSwapInto: (String, Int) -> Unit,
+    controller: DashboardDragController
+) {
+    val surfaceColor = MaterialTheme.colorScheme.surfaceVariant
+    val outlineColor = MaterialTheme.colorScheme.outlineVariant
+    val accent = MaterialTheme.colorScheme.primary
+    val isBeingDragged = controller.draggingKey == id
+    val isDropTarget = controller.isDragging &&
+        controller.draggingKey != id &&
+        controller.hoveredTarget?.slotIndex == slotIndex &&
+        controller.sourceKind == DragSourceKind.METRIC
+    val borderColor by androidx.compose.animation.animateColorAsState(
+        targetValue = if (isDropTarget) accent else outlineColor,
+        label = "custom-tile-border"
+    )
+    val borderWidth by androidx.compose.animation.core.animateDpAsState(
+        targetValue = if (isDropTarget) 2.dp else 1.dp,
+        label = "custom-tile-border-w"
+    )
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(10.dp))
+            .background(surfaceColor)
+            .border(borderWidth, borderColor, RoundedCornerShape(10.dp))
+            .clickable(onClick = onTap)
+            .dashboardDragSource(
+                key = id,
+                value = "",
+                sourceKind = DragSourceKind.METRIC,
+                controller = controller,
+                fromGrid = true
+            )
+            .dashboardDropTarget(
+                key = "metric-slot-$slotIndex",
+                kind = DropKind.METRIC_GRID_SLOT,
+                slotIndex = slotIndex,
+                controller = controller,
+                onDrop = { sourceKey -> onSwapInto(sourceKey, slotIndex) }
+            )
+    ) {
+        Box(modifier = Modifier.fillMaxSize().alpha(if (isBeingDragged) 0f else 1f)) {
+            CustomTileBody(tile = tile)
+            // Action badge — small icon hugging the bottom-right corner.
+            // Tells the rider at a glance whether tapping the tile will
+            // launch a browser or show a QR code popup.
+            val badge = actionBadgeIcon(tile.action)
+            if (badge != null) {
+                Icon(
+                    badge,
+                    contentDescription = null,
+                    tint = accent.copy(alpha = 0.85f),
+                    modifier = Modifier
+                        .size(14.dp)
+                        .padding(0.dp)
+                        .align(Alignment.BottomEnd)
+                        .padding(end = 4.dp, bottom = 3.dp)
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Inner body of a custom tile (icon + text, with domain fallback for blank
+ * text). Public-internal so the live dashboard renders the same content; the
+ * editor adds the dashed-border drag-source wrapper, the live dashboard adds
+ * the actual tap-action handler.
+ */
+@Composable
+fun CustomTileBody(tile: CustomTile) {
+    val labelOrFallback = tile.text.ifBlank { extractDomainHint(tile.url) }
+    val labelColor = if (tile.text.isBlank() && tile.url.isBlank())
+        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+        else MaterialTheme.colorScheme.onSurfaceVariant
+    val labelStyle = if (tile.text.isBlank() && tile.url.isBlank())
+        androidx.compose.ui.text.font.FontStyle.Italic
+        else androidx.compose.ui.text.font.FontStyle.Normal
+    val displayText = labelOrFallback.ifBlank { stringResource(R.string.dashboard_composite_empty_label) }
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 6.dp, vertical = 6.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            groupIconFor(tile.icon),
+            contentDescription = null,
+            modifier = Modifier.size(22.dp),
+            tint = MaterialTheme.colorScheme.primary
+        )
+        Spacer(Modifier.height(2.dp))
+        Text(
+            displayText,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Medium,
+            fontStyle = labelStyle,
+            color = labelColor,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+/** Picks the small bottom-right badge icon based on the rider's tap-action
+ *  choice. None = no badge (tile is display-only). */
+internal fun actionBadgeIcon(action: CustomTileAction): ImageVector? = when (action) {
+    CustomTileAction.NONE -> null
+    CustomTileAction.OPEN_URL -> Icons.Filled.Link
+    CustomTileAction.SHOW_QR -> Icons.Filled.QrCode2
+}
+
+/**
+ * Strips a URL down to a short domain hint suitable as a fallback tile
+ * label. Drops scheme, "www.", and any path so "https://www.instagram.com/foo"
+ * reads as "instagram.com". Returns the input verbatim when it doesn't look
+ * like a URL the rider can recognise.
+ */
+internal fun extractDomainHint(url: String): String {
+    if (url.isBlank()) return ""
+    val noScheme = url
+        .substringAfter("://", missingDelimiterValue = url)
+        .substringAfter("@", missingDelimiterValue = url.substringAfter("://", url))
+    val host = noScheme.substringBefore("/").substringBefore("?").substringBefore("#")
+    val trimmed = host.removePrefix("www.").trim()
+    return trimmed.ifBlank { url }
+}
+
+
+/**
+ * Pool-sized variant of a composite tile. Same swap-with-grid drag semantics
+ * as a regular pool pill, but renders the composite's actual layout + cells
+ * inside the 102×52 pill so the rider sees what they have rather than the
+ * raw "M:abc12345" ID. Tap routes to the composite edit sheet.
+ */
+@Composable
+private fun CompositePoolPill(
+    id: String,
+    composite: MetricComposite,
+    valueOf: (String) -> String,
+    onTap: (String) -> Unit,
+    controller: DashboardDragController
+) {
+    val surfaceColor = MaterialTheme.colorScheme.surfaceVariant
+    val outlineColor = MaterialTheme.colorScheme.outlineVariant
+    val isBeingDragged = controller.draggingKey == id
+    Box(
+        modifier = Modifier
+            .width(102.dp)
+            .height(52.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(surfaceColor)
+            .border(1.dp, outlineColor, RoundedCornerShape(10.dp))
+            .clickable { onTap(id) }
+            .dashboardDragSource(
+                key = id,
+                value = "",
+                sourceKind = DragSourceKind.METRIC,
+                controller = controller,
+                fromGrid = false
+            )
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .alpha(if (isBeingDragged) 0f else 1f)
+        ) {
+            CompositeMetricBody(composite = composite, valueOf = valueOf)
+        }
+    }
+}
+
+/**
+ * Pool-sized variant of a custom tile. Renders the icon + text exactly like
+ * a grid tile so a custom tile that ends up in the pool (via swap with a
+ * pool metric) shows up as itself rather than the raw "C:abc12345" ID.
+ */
+@Composable
+private fun CustomTilePoolPill(
+    id: String,
+    tile: CustomTile,
+    onTap: (String) -> Unit,
+    controller: DashboardDragController
+) {
+    val surfaceColor = MaterialTheme.colorScheme.surfaceVariant
+    val outlineColor = MaterialTheme.colorScheme.outlineVariant
+    val accent = MaterialTheme.colorScheme.primary
+    val isBeingDragged = controller.draggingKey == id
+    Box(
+        modifier = Modifier
+            .width(102.dp)
+            .height(52.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(surfaceColor)
+            .border(1.dp, outlineColor, RoundedCornerShape(10.dp))
+            .clickable { onTap(id) }
+            .dashboardDragSource(
+                key = id,
+                value = "",
+                sourceKind = DragSourceKind.METRIC,
+                controller = controller,
+                fromGrid = false
+            )
+    ) {
+        Box(modifier = Modifier.fillMaxSize().alpha(if (isBeingDragged) 0f else 1f)) {
+            CustomTileBody(tile = tile)
+            actionBadgeIcon(tile.action)?.let { badge ->
+                Icon(
+                    badge,
+                    contentDescription = null,
+                    tint = accent.copy(alpha = 0.85f),
+                    modifier = Modifier
+                        .size(12.dp)
+                        .align(Alignment.BottomEnd)
+                        .padding(end = 4.dp, bottom = 3.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MetricPoolPill(
+    key: String,
+    value: String,
+    statsEnabled: Boolean,
+    onTap: (String) -> Unit,
+    controller: DashboardDragController
+) {
+    val accent = metricAccentColor(key)
+    val label = metricChipLabel(key)
+    val surfaceColor = MaterialTheme.colorScheme.surfaceVariant
+    val outlineColor = MaterialTheme.colorScheme.outlineVariant
+    val isBeingDragged = controller.draggingKey == key
+    // Sized so three pills + two 6dp gaps fit inside the pool container at
+    // phone width (~360dp usable after section + container padding).
+    val supportsStats = metricSupportsStats(key)
+    Box(
+        modifier = Modifier
+            .width(102.dp)
+            .height(52.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(surfaceColor)
+            .border(1.dp, outlineColor, RoundedCornerShape(10.dp))
+            .clickable { onTap(key) }
+            .dashboardDragSource(
+                key = key,
+                value = value,
+                sourceKind = DragSourceKind.METRIC,
+                controller = controller,
+                fromGrid = false
+            )
+    ) {
+        // Sparkline background mirrors the grid tiles' style. Three states:
+        // active (full accent), dimmed (gray ghost — disabled but available
+        // to re-enable on tap), or absent (metric doesn't support stats —
+        // counters / heading). No corner icon: the wave itself is the
+        // indicator.
+        if (supportsStats) {
+            val waveColor = if (statsEnabled) accent
+                else MaterialTheme.colorScheme.onSurfaceVariant
+            WavePatternBackground(
+                accent = waveColor,
+                dimmed = !statsEnabled,
+                modifier = Modifier.alpha(if (isBeingDragged) 0f else 1f)
+            )
+        }
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 6.dp, vertical = 4.dp)
+                .alpha(if (isBeingDragged) 0f else 1f),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                label.uppercase(),
+                fontSize = 9.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontWeight = FontWeight.Medium,
+                letterSpacing = 0.5.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Spacer(Modifier.height(1.dp))
+            Text(
+                value,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.Bold,
+                color = accent,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}
+
+// ---- Action grid -------------------------------------------------------
+
+@OptIn(androidx.compose.animation.ExperimentalSharedTransitionApi::class)
+@Composable
+private fun ActionMiniGrid(
+    order: List<String>,
+    activeCount: Int,
+    columns: Int,
+    groupOf: (String) -> ActionGroup?,
+    onSwapInto: (String, Int) -> Unit,
+    onTapTile: (String, Int) -> Unit,
+    controller: DashboardDragController
+) {
+    val active = order.take(activeCount)
+    val rows = (active.size + columns - 1) / columns
+    androidx.compose.ui.layout.LookaheadScope {
+        val lookahead = this
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            for (rowIdx in 0 until rows) {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    for (colIdx in 0 until columns) {
+                        val slotIndex = rowIdx * columns + colIdx
+                        val key = active.getOrNull(slotIndex)
+                        if (key != null) {
+                            androidx.compose.runtime.key(key) {
+                                val tileMod = Modifier
+                                    .weight(1f)
+                                    .height(86.dp)
+                                    .animateBounds(
+                                        lookaheadScope = lookahead,
+                                        boundsTransform = dashboardTileBoundsTransform
+                                    )
+                                if (isActionGroupKey(key)) {
+                                    val group = groupOf(key) ?: ActionGroup()
+                                    ActionGroupTile(
+                                        id = key,
+                                        group = group,
+                                        slotIndex = slotIndex,
+                                        modifier = tileMod,
+                                        onSwapInto = onSwapInto,
+                                        onTap = { onTapTile(key, slotIndex) },
+                                        controller = controller
+                                    )
+                                } else {
+                                    ActionTile(
+                                        key = key,
+                                        slotIndex = slotIndex,
+                                        modifier = tileMod,
+                                        onSwapInto = onSwapInto,
+                                        onTap = { onTapTile(key, slotIndex) },
+                                        controller = controller
+                                    )
+                                }
+                            }
+                        } else {
+                            Box(modifier = Modifier.weight(1f))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ActionTile(
+    key: String,
+    slotIndex: Int,
+    modifier: Modifier,
+    onSwapInto: (String, Int) -> Unit,
+    onTap: () -> Unit,
+    controller: DashboardDragController
+) {
+    val icon = dashboardActionIcon(key)
+    val label = actionChipLabel(key)
+    val surfaceColor = MaterialTheme.colorScheme.surfaceVariant
+    val outlineColor = MaterialTheme.colorScheme.outlineVariant
+    val accent = MaterialTheme.colorScheme.primary
+    val isBeingDragged = controller.draggingKey == key
+    val isDropTarget = controller.isDragging &&
+        controller.draggingKey != key &&
+        controller.hoveredTarget?.slotIndex == slotIndex &&
+        controller.sourceKind == DragSourceKind.ACTION
+    val borderColor by androidx.compose.animation.animateColorAsState(
+        targetValue = if (isDropTarget) accent else outlineColor,
+        label = "action-tile-border"
+    )
+    val borderWidth by androidx.compose.animation.core.animateDpAsState(
+        targetValue = if (isDropTarget) 2.dp else 1.dp,
+        label = "action-tile-border-w"
+    )
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(10.dp))
+            .background(surfaceColor)
+            .border(borderWidth, borderColor, RoundedCornerShape(10.dp))
+            .clickable(onClick = onTap)
+            .dashboardDragSource(
+                key = key,
+                value = "",
+                sourceKind = DragSourceKind.ACTION,
+                controller = controller,
+                fromGrid = true
+            )
+            .dashboardDropTarget(
+                key = "action-slot-$slotIndex",
+                kind = DropKind.ACTION_GRID_SLOT,
+                slotIndex = slotIndex,
+                controller = controller,
+                onDrop = { sourceKey -> onSwapInto(sourceKey, slotIndex) }
+            )
+    ) {
+        // Icon anchored at a fixed top offset so the cluster reads as
+        // visually centred for a 1-line label, and a 2-line label simply
+        // extends below the icon without pushing the icon up. Math: 86dp
+        // tile minus (26dp icon + 4dp gap + 14dp 1-line text) = 42dp of
+        // free space, halved = 21dp top padding for true centre.
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(start = 4.dp, end = 4.dp, top = 21.dp)
+                .alpha(if (isBeingDragged) 0f else 1f),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            if (icon != null) {
+                Icon(
+                    icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(26.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(Modifier.height(4.dp))
+            }
+            Text(
+                label,
+                fontSize = 11.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+/**
+ * Resolves a curated [GROUP_ICON_CHOICES] key to a Material icon. Used by
+ * both [ActionGroupTile] and the icon picker in [ActionGroupSheet] so the
+ * tile preview and the picker stay in sync — change one key here, both
+ * surfaces update.
+ */
+internal fun groupIconFor(key: String): ImageVector = when (key) {
+    "FOLDER" -> Icons.Filled.Folder
+    "STAR" -> Icons.Filled.Star
+    "BOLT" -> Icons.Filled.Bolt
+    "FAVORITE" -> Icons.Filled.Favorite
+    "DASHBOARD" -> Icons.Filled.Dashboard
+    "EXTENSION" -> Icons.Filled.Extension
+    "TUNE" -> Icons.Filled.Tune
+    "WIDGETS" -> Icons.Filled.Widgets
+    "APPS" -> Icons.Filled.Apps
+    "BUILD" -> Icons.Filled.Build
+    "HOME" -> Icons.Filled.Home
+    "PERSON" -> Icons.Filled.Person
+    "SETTINGS" -> Icons.Filled.Settings
+    "SHIELD" -> Icons.Filled.Shield
+    "MAP" -> Icons.Filled.Map
+    "PHOTO_CAMERA" -> Icons.Filled.PhotoCamera
+    "MUSIC_NOTE" -> Icons.Filled.MusicNote
+    "PHONE" -> Icons.Filled.Phone
+    "WIFI" -> Icons.Filled.Wifi
+    "SEARCH" -> Icons.Filled.Search
+    "SAVE" -> Icons.Filled.Save
+    "SEND" -> Icons.Filled.Send
+    "SHARE" -> Icons.Filled.Share
+    "EDIT" -> Icons.Filled.Edit
+    "REFRESH" -> Icons.Filled.Refresh
+    "DONE" -> Icons.Filled.Done
+    "INFO" -> Icons.Filled.Info
+    "WARNING" -> Icons.Filled.Warning
+    "NOTIFICATIONS" -> Icons.Filled.Notifications
+    "LINK" -> Icons.Filled.Link
+    else -> Icons.Filled.Folder
+}
+
+/**
+ * Action-group tile. Renders the rider's chosen icon + name. Tap opens the
+ * group edit sheet; long-press drags the whole group as a single unit (the
+ * sub-actions move with it). Same drop-target semantics as a regular
+ * [ActionTile] so the rider can swap a group with a plain action.
+ */
+@Composable
+private fun ActionGroupTile(
+    id: String,
+    group: ActionGroup,
+    slotIndex: Int,
+    modifier: Modifier,
+    onSwapInto: (String, Int) -> Unit,
+    onTap: () -> Unit,
+    controller: DashboardDragController
+) {
+    val icon = groupIconFor(group.icon)
+    val label = group.name.ifBlank { stringResource(R.string.dashboard_group_default_name) }
+    val surfaceColor = MaterialTheme.colorScheme.surfaceVariant
+    val outlineColor = MaterialTheme.colorScheme.outlineVariant
+    val accent = MaterialTheme.colorScheme.primary
+    val isBeingDragged = controller.draggingKey == id
+    val isDropTarget = controller.isDragging &&
+        controller.draggingKey != id &&
+        controller.hoveredTarget?.slotIndex == slotIndex &&
+        controller.sourceKind == DragSourceKind.ACTION
+    val borderColor by androidx.compose.animation.animateColorAsState(
+        targetValue = if (isDropTarget) accent else outlineColor,
+        label = "group-tile-border"
+    )
+    val borderWidth by androidx.compose.animation.core.animateDpAsState(
+        targetValue = if (isDropTarget) 2.dp else 1.dp,
+        label = "group-tile-border-w"
+    )
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(10.dp))
+            .background(surfaceColor)
+            .border(borderWidth, borderColor, RoundedCornerShape(10.dp))
+            .clickable(onClick = onTap)
+            .dashboardDragSource(
+                key = id,
+                value = "",
+                sourceKind = DragSourceKind.ACTION,
+                controller = controller,
+                fromGrid = true
+            )
+            .dashboardDropTarget(
+                key = "action-slot-$slotIndex",
+                kind = DropKind.ACTION_GRID_SLOT,
+                slotIndex = slotIndex,
+                controller = controller,
+                onDrop = { sourceKey -> onSwapInto(sourceKey, slotIndex) }
+            )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(start = 4.dp, end = 4.dp, top = 21.dp)
+                .alpha(if (isBeingDragged) 0f else 1f),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(
+                icon,
+                contentDescription = null,
+                modifier = Modifier.size(26.dp),
+                // Tinted with the accent so the group reads as "different
+                // from a plain action" without needing a separate badge.
+                tint = accent
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                label,
+                fontSize = 11.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+/**
+ * Action pool = catalog. Renders the group template followed by every key
+ * in [catalogKeys] sorted alphabetically by display label. Action groups
+ * are dynamic instances and only live in the grid — pool drops only handle
+ * group deletion. Pool→pool drags of static actions land as no-ops because
+ * a static action can't be "removed" from the catalog.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun ActionPool(
+    catalogKeys: List<String>,
+    onTap: (String) -> Unit,
+    onDeleteGroup: (String) -> Unit,
+    controller: DashboardDragController
+) {
+    val labeled = catalogKeys.map { it to actionChipLabel(it) }
+    val sorted = labeled.sortedBy { it.second.uppercase() }.map { it.first }
+    val density = LocalDensity.current
+    val poolPillSizePx = androidx.compose.runtime.remember(density) {
+        with(density) { androidx.compose.ui.unit.IntSize(102.dp.roundToPx(), 66.dp.roundToPx()) }
+    }
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(max = 254.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.4f))
+            .dashboardHintRegion(
+                key = "action-pool",
+                sourceKind = DragSourceKind.ACTION,
+                expectedSizePx = poolPillSizePx,
+                controller = controller
+            )
+            // Trash for action-group instances. The predicate ensures regular
+            // pool pills and the template drag pass through unaffected, and
+            // overrideExpectedSizePx previews the tile shrinking to pool-pill
+            // size so the rider sees "this is being deleted" instead of the
+            // tile growing to fill the whole pool.
+            .dashboardDropTarget(
+                key = "action-pool-trash",
+                kind = DropKind.ACTION_POOL_TRASH,
+                controller = controller,
+                onDrop = { sourceKey ->
+                    // Only grid-sourced groups get deleted. Static actions
+                    // can't be removed from the catalog; pool→pool drags
+                    // are no-ops by the same rule.
+                    if (controller.sourceFromGrid && isActionGroupKey(sourceKey)) {
+                        onDeleteGroup(sourceKey)
+                    }
+                },
+                acceptsSourceKey = { sourceKey -> isActionGroupKey(sourceKey) },
+                overrideExpectedSizePx = poolPillSizePx
+            )
+            .verticalScroll(rememberScrollState())
+            .padding(8.dp)
+    ) {
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            // Group template lives at the head of the pool as an always-
+            // available source. Dragging it onto a grid slot spawns a new
+            // group instance; the template stays here because we render it
+            // unconditionally rather than from the order list.
+            ActionGroupTemplatePill(controller = controller)
+            sorted.forEach { key ->
+                ActionPoolPill(key = key, onTap = onTap, controller = controller)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ActionGroupTemplatePill(
+    controller: DashboardDragController
+) {
+    val outlineColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f)
+    val labelColor = MaterialTheme.colorScheme.primary
+    val density = LocalDensity.current
+    val dashSpec = remember(density) {
+        androidx.compose.ui.graphics.drawscope.Stroke(
+            width = with(density) { 1.5.dp.toPx() },
+            pathEffect = androidx.compose.ui.graphics.PathEffect.dashPathEffect(
+                floatArrayOf(
+                    with(density) { 4.dp.toPx() },
+                    with(density) { 3.dp.toPx() }
+                )
+            )
+        )
+    }
+    val cornerRadiusPx = with(density) { 10.dp.toPx() }
+    val isBeingDragged = controller.draggingKey == ACTION_GROUP_TEMPLATE_KEY
+    Box(
+        modifier = Modifier
+            .width(102.dp)
+            .height(66.dp)
+            .drawBehind {
+                drawRoundRect(
+                    color = outlineColor,
+                    cornerRadius = androidx.compose.ui.geometry.CornerRadius(cornerRadiusPx),
+                    style = dashSpec
+                )
+            }
+            // Same action-source semantics as a pool pill — the controller
+            // treats this drag like a regular action move and the downstream
+            // drop callback routes the template key to createActionGroupAt.
+            .dashboardDragSource(
+                key = ACTION_GROUP_TEMPLATE_KEY,
+                value = "",
+                sourceKind = DragSourceKind.ACTION,
+                controller = controller,
+                fromGrid = false
+            )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 6.dp, vertical = 6.dp)
+                .alpha(if (isBeingDragged) 0.4f else 1f),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Add,
+                contentDescription = null,
+                tint = labelColor,
+                modifier = Modifier.size(22.dp)
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                stringResource(R.string.dashboard_group_template_label),
+                fontSize = 10.sp,
+                color = labelColor,
+                fontWeight = FontWeight.Medium,
+                letterSpacing = 0.5.sp,
+                maxLines = 1
+            )
+        }
+    }
+}
+
+/**
+ * Pool-sized variant of an action-group tile. Same drag-to-grid semantics
+ * as [ActionPoolPill] but renders the group's chosen icon + name inside
+ * the 102×66 pool pill so a group dragged into the pool (via swap) shows
+ * up as itself rather than the raw "G:abc12345" key.
+ */
+@Composable
+private fun ActionGroupPoolPill(
+    id: String,
+    group: ActionGroup,
+    onTap: (String) -> Unit,
+    controller: DashboardDragController
+) {
+    val icon = groupIconFor(group.icon)
+    val label = group.name.ifBlank { stringResource(R.string.dashboard_group_default_name) }
+    val surfaceColor = MaterialTheme.colorScheme.surfaceVariant
+    val outlineColor = MaterialTheme.colorScheme.outlineVariant
+    val accent = MaterialTheme.colorScheme.primary
+    val isBeingDragged = controller.draggingKey == id
+    Box(
+        modifier = Modifier
+            .width(102.dp)
+            .height(66.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(surfaceColor)
+            .border(1.dp, outlineColor, RoundedCornerShape(10.dp))
+            .clickable { onTap(id) }
+            .dashboardDragSource(
+                key = id,
+                value = "",
+                sourceKind = DragSourceKind.ACTION,
+                controller = controller,
+                fromGrid = false
+            )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 4.dp, vertical = 6.dp)
+                .alpha(if (isBeingDragged) 0f else 1f),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                icon,
+                contentDescription = null,
+                modifier = Modifier.size(22.dp),
+                tint = accent
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                label,
+                fontSize = 10.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontWeight = FontWeight.Medium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+@Composable
+private fun ActionPoolPill(
+    key: String,
+    onTap: (String) -> Unit,
+    controller: DashboardDragController
+) {
+    val icon = dashboardActionIcon(key)
+    val label = actionChipLabel(key)
+    val surfaceColor = MaterialTheme.colorScheme.surfaceVariant
+    val outlineColor = MaterialTheme.colorScheme.outlineVariant
+    val isBeingDragged = controller.draggingKey == key
+    Box(
+        modifier = Modifier
+            .width(102.dp)
+            .height(66.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(surfaceColor)
+            .border(1.dp, outlineColor, RoundedCornerShape(10.dp))
+            .clickable { onTap(key) }
+            .dashboardDragSource(
+                key = key,
+                value = "",
+                sourceKind = DragSourceKind.ACTION,
+                controller = controller,
+                fromGrid = false
+            )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(start = 4.dp, end = 4.dp, top = 16.dp)
+                .alpha(if (isBeingDragged) 0f else 1f),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            if (icon != null) {
+                Icon(
+                    icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(Modifier.height(3.dp))
+            }
+            Text(
+                label,
+                fontSize = 9.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+// ---- Per-slot bottom sheet --------------------------------------------
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DashboardSlotSheet(
+    target: DashboardEditTarget,
+    settings: com.eried.eucplanet.data.model.AppSettings,
+    viewModel: SettingsViewModel,
+    onDismiss: () -> Unit,
+    onReset: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState()
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            when (target) {
+                is DashboardEditTarget.Metric -> {
+                    val stats = viewModel.dashboardMetricSlotStats(settings, target.key)
+                    SlotSheetMetricPreview(
+                        key = target.key,
+                        stats = stats,
+                        valueOf = { metricPlaceholderValue(target.key, settings) },
+                        onSparklineChange = { enabled ->
+                            viewModel.updateDashboardMetricSparkline(target.key, enabled)
+                        }
+                    )
+                    metricDescription(target.key)?.let { MetricInfoBox(it) }
+                    SlotStatsEditor(
+                        key = target.key,
+                        stats = stats,
+                        onCornerChange = { corner, stat ->
+                            viewModel.updateDashboardMetricSlotStat(target.key, corner, stat)
+                        }
+                    )
+                }
+                is DashboardEditTarget.Action -> SlotSheetActionPreview(target.key)
+                // Composite, group + custom-tile instances route to their
+                // dedicated sheets upstream so these branches are unreachable;
+                // keeping them for `when` exhaustiveness.
+                is DashboardEditTarget.Composite,
+                is DashboardEditTarget.Group,
+                is DashboardEditTarget.CustomTile -> Unit
+            }
+            SlotSheetFooter(onReset, onDismiss)
+            Spacer(Modifier.height(8.dp))
+        }
+    }
+}
+
+/**
+ * Edit sheet for a composite-metric instance. Lets the rider pick the layout
+ * (2-row, 2-col, 3-col) and which sub-metrics fill each cell. Deliberately
+ * stats-free; the rider deletes the instance by dragging the tile off the
+ * grid OR by hitting "Default metric" — which restores the slot to its
+ * shipped occupant and removes the composite definition.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CompositeMetricSheet(
+    id: String,
+    settings: com.eried.eucplanet.data.model.AppSettings,
+    viewModel: SettingsViewModel,
+    onDismiss: () -> Unit,
+    onReset: () -> Unit
+) {
+    val composite = viewModel.getCompositeMetric(settings, id) ?: MetricComposite()
+    // Composite sheets now carry two dropdown rows per cell (metric +
+    // stat) plus the preview + layout switcher, so the default half-
+    // height bottom sheet feels cramped. Skip the partial state so
+    // the sheet opens at full height by default.
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var layout by remember(id, composite.layout) { mutableStateOf(composite.layout) }
+    val baseCells = remember(id, composite.cells) {
+        // Pad/truncate to 3 slots (the maximum any layout uses) so the
+        // dropdowns never reach for a missing index. EMPTY is the safe
+        // default for unused cells — switching to a wider layout reveals
+        // a blank slot rather than auto-injecting a duplicate metric.
+        val seeded = composite.cells + List(3) { COMPOSITE_CELL_EMPTY }
+        androidx.compose.runtime.mutableStateListOf<String>().apply { addAll(seeded.take(3)) }
+    }
+    val baseStats = remember(id, composite.cellStats) {
+        val seeded = composite.cellStats + List(3) { DashboardStat.CURRENT }
+        androidx.compose.runtime.mutableStateListOf<DashboardStat>().apply { addAll(seeded.take(3)) }
+    }
+    val padded: List<String> = baseCells.take(layout.cellCount) +
+        List((layout.cellCount - baseCells.size).coerceAtLeast(0)) { COMPOSITE_CELL_EMPTY }
+    val paddedStats: List<DashboardStat> = baseStats.take(layout.cellCount) +
+        List((layout.cellCount - baseStats.size).coerceAtLeast(0)) { DashboardStat.CURRENT }
+
+    fun persist(newLayout: CompositeLayout, newCells: List<String>, newStats: List<DashboardStat>) {
+        viewModel.updateCompositeMetric(
+            id,
+            newLayout,
+            newCells.take(newLayout.cellCount),
+            newStats.take(newLayout.cellCount)
+        )
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            // Live preview of the composite using the current layout + cells.
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(140.dp)
+                    .clip(RoundedCornerShape(14.dp))
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                    .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(14.dp))
+            ) {
+                CompositeMetricBody(
+                    composite = MetricComposite(layout, padded, paddedStats),
+                    valueOf = { k -> metricPlaceholderValue(k, settings) }
+                )
+            }
+
+            // Layout segmented control — three mutually-exclusive options
+            // (2 rows / 2 cols / 3 cols) feel more like a single switch
+            // when bound together as a segmented row rather than three
+            // independent chips. No title; the labels speak for themselves.
+            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                val options = CompositeLayout.values()
+                options.forEachIndexed { index, lay ->
+                    SegmentedButton(
+                        selected = layout == lay,
+                        onClick = {
+                            layout = lay
+                            persist(lay, baseCells, baseStats)
+                        },
+                        shape = SegmentedButtonDefaults.itemShape(index, options.size)
+                    ) {
+                        Text(compositeLayoutLabel(lay))
+                    }
+                }
+            }
+
+            // Two-row picker per cell:
+            //   row 1 = which metric
+            //   row 2 = which stat (Now / Min / Max / Avg / percentiles…)
+            // 3 columns regardless of layout — cells past the active layout's
+            // cell count grey out instead of disappearing, so the row's
+            // overall height never jumps when the rider switches between
+            // ROW2/COL2 (2 cells) and COL3 (3 cells).
+            val cellCatalog = remember(viewModel) {
+                listOf(COMPOSITE_CELL_EMPTY) + viewModel.knownDashboardMetrics
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                for (cellIndex in 0 until 3) {
+                    val enabled = cellIndex < layout.cellCount
+                    CompositeCellDropdown(
+                        label = stringResource(R.string.dashboard_composite_cell_label, cellIndex + 1),
+                        currentKey = baseCells.getOrNull(cellIndex) ?: "SPEED",
+                        options = cellCatalog,
+                        enabled = enabled,
+                        onSelect = { newKey ->
+                            baseCells[cellIndex] = newKey
+                            persist(layout, baseCells, baseStats)
+                        },
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                for (cellIndex in 0 until 3) {
+                    val enabled = cellIndex < layout.cellCount
+                    CompositeCellStatDropdown(
+                        currentStat = baseStats.getOrNull(cellIndex) ?: DashboardStat.CURRENT,
+                        enabled = enabled,
+                        onSelect = { newStat ->
+                            baseStats[cellIndex] = newStat
+                            persist(layout, baseCells, baseStats)
+                        },
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+            }
+
+            SlotSheetFooter(onReset, onDismiss)
+            Spacer(Modifier.height(8.dp))
+        }
+    }
+}
+
+/**
+ * Shared footer for every per-slot bottom sheet: Restore on the left,
+ * Close on the right. The "Restore slot" label is uniform across metric
+ * and action sheets so it translates as a single string.
+ */
+@Composable
+private fun SlotSheetFooter(
+    onReset: () -> Unit,
+    onClose: () -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        TextButton(onClick = onReset) {
+            Icon(
+                Icons.Filled.Restore,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp)
+            )
+            Spacer(Modifier.width(6.dp))
+            Text(stringResource(R.string.dashboard_restore_slot))
+        }
+        Spacer(Modifier.weight(1f))
+        FilledTonalButton(onClick = onClose) {
+            Text(stringResource(R.string.dashboard_close))
+        }
+    }
+}
+
+@Composable
+internal fun compositeLayoutLabel(layout: CompositeLayout): String = when (layout) {
+    CompositeLayout.ROW2 -> stringResource(R.string.dashboard_composite_layout_row2)
+    CompositeLayout.COL2 -> stringResource(R.string.dashboard_composite_layout_col2)
+    CompositeLayout.COL3 -> stringResource(R.string.dashboard_composite_layout_col3)
+}
+
+/**
+ * Dropdown letting the rider choose which catalog metric fills a composite
+ * cell. Reuses the same `metricChipLabel` mapping the rest of the editor
+ * uses so labels stay in sync. [enabled] is false for cells past the
+ * active layout's cell count — the field greys out instead of disappearing
+ * so the row's footprint stays stable as the rider switches layouts.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CompositeCellDropdown(
+    label: String,
+    currentKey: String,
+    options: List<String>,
+    enabled: Boolean,
+    onSelect: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(
+        expanded = expanded && enabled,
+        onExpandedChange = { if (enabled) expanded = !expanded },
+        modifier = modifier
+    ) {
+        OutlinedTextField(
+            value = metricChipLabel(currentKey),
+            onValueChange = {},
+            readOnly = true,
+            singleLine = true,
+            enabled = enabled,
+            label = { Text(label) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded && enabled) },
+            modifier = Modifier
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable, enabled = enabled)
+                .fillMaxWidth()
+        )
+        ExposedDropdownMenu(
+            expanded = expanded && enabled,
+            onDismissRequest = { expanded = false }
+        ) {
+            options.forEach { key ->
+                DropdownMenuItem(
+                    text = { Text(metricChipLabel(key)) },
+                    onClick = {
+                        onSelect(key)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Stat picker dropdown used under each composite cell. Lets the rider
+ * choose what the cell shows for its metric: Now (live value), Min, Max,
+ * Avg, Sustained peak, Median, P75, P95, P99 — all computed from the
+ * rolling history buffer for that metric. Greys out when the parent cell
+ * is past the active layout's cell count.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CompositeCellStatDropdown(
+    currentStat: DashboardStat,
+    enabled: Boolean,
+    onSelect: (DashboardStat) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val options = remember {
+        // Same option list the History screen used to expose. NONE is
+        // omitted because "show nothing in this cell" already has its
+        // own mechanism (the EMPTY metric key on the row above).
+        listOf(
+            DashboardStat.CURRENT,
+            DashboardStat.MIN,
+            DashboardStat.MAX,
+            DashboardStat.AVG,
+            DashboardStat.SUSTAINED_PEAK,
+            DashboardStat.MEDIAN,
+            DashboardStat.P75,
+            DashboardStat.P95,
+            DashboardStat.P99
+        )
+    }
+    ExposedDropdownMenuBox(
+        expanded = expanded && enabled,
+        onExpandedChange = { if (enabled) expanded = !expanded },
+        modifier = modifier
+    ) {
+        OutlinedTextField(
+            value = compositeCellStatLabel(currentStat),
+            onValueChange = {},
+            readOnly = true,
+            singleLine = true,
+            enabled = enabled,
+            label = { Text(stringResource(R.string.metric_detail_show_label)) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded && enabled) },
+            modifier = Modifier
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable, enabled = enabled)
+                .fillMaxWidth()
+        )
+        ExposedDropdownMenu(
+            expanded = expanded && enabled,
+            onDismissRequest = { expanded = false }
+        ) {
+            options.forEach { opt ->
+                DropdownMenuItem(
+                    text = { Text(compositeCellStatLabel(opt)) },
+                    onClick = {
+                        onSelect(opt)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun compositeCellStatLabel(stat: DashboardStat): String = when (stat) {
+    DashboardStat.NONE -> "—"
+    DashboardStat.CURRENT -> stringResource(R.string.dashboard_stat_current)
+    DashboardStat.MIN -> stringResource(R.string.dashboard_stat_min)
+    DashboardStat.MAX -> stringResource(R.string.dashboard_stat_max)
+    DashboardStat.SUSTAINED_PEAK -> stringResource(R.string.dashboard_stat_sustained_peak)
+    DashboardStat.AVG -> stringResource(R.string.dashboard_stat_avg)
+    DashboardStat.MEDIAN -> stringResource(R.string.dashboard_stat_median)
+    DashboardStat.P75 -> stringResource(R.string.dashboard_stat_p75)
+    DashboardStat.P95 -> stringResource(R.string.dashboard_stat_p95)
+    DashboardStat.P99 -> stringResource(R.string.dashboard_stat_p99)
+}
+
+/**
+ * Edit sheet for an action-group instance. Lets the rider rename the group,
+ * pick its tile icon from a curated 10-icon set, and configure up to four
+ * sub-actions in chosen order. Duplicate sub-actions are allowed (the rider
+ * may want the same action twice in a popover — e.g. two RECORD_TOGGLE
+ * entries). No reset / delete buttons — deletion happens by dragging the
+ * tile back to the pool.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ActionGroupSheet(
+    id: String,
+    settings: com.eried.eucplanet.data.model.AppSettings,
+    viewModel: SettingsViewModel,
+    onDismiss: () -> Unit,
+    onReset: () -> Unit
+) {
+    val group = viewModel.getActionGroup(settings, id) ?: ActionGroup()
+    val sheetState = rememberModalBottomSheetState()
+    val defaultName = stringResource(R.string.dashboard_group_default_name)
+    var name by remember(id, group.name) { mutableStateOf(group.name) }
+    var icon by remember(id, group.icon) { mutableStateOf(group.icon) }
+    val actionSlots = remember(id, group.actions) {
+        val seeded = group.actions + List(4) { "" }
+        androidx.compose.runtime.mutableStateListOf<String>().apply { addAll(seeded.take(4)) }
+    }
+
+    fun persist() {
+        viewModel.updateActionGroup(
+            id = id,
+            name = name,
+            icon = icon,
+            actions = actionSlots.filter { it.isNotEmpty() }
+        )
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            // Preview tile intentionally omitted — the icon-picker button
+            // already shows what the group's icon looks like, and the
+            // name field shows the label. A full-width preview here would
+            // duplicate both for no extra information.
+
+            // Compact name + icon row. The icon lives as a leading button
+            // inside the OutlinedTextField's row so the picker takes zero
+            // extra vertical space — the rider can scan through icons from
+            // a popup grid without scrolling the sheet.
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                // Wrap in a top-padded Box so the icon-button centers
+                // against the labelled OutlinedTextField (the floating
+                // label adds ~8dp at the top). Mirrors the CustomTileSheet
+                // icon-text band.
+                Box(
+                    modifier = Modifier.padding(top = 8.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    GroupIconButton(
+                        currentKey = icon,
+                        onSelect = {
+                            icon = it
+                            persist()
+                        }
+                    )
+                }
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = {
+                        name = it
+                        persist()
+                    },
+                    singleLine = true,
+                    label = { Text(stringResource(R.string.dashboard_group_name_label)) },
+                    placeholder = { Text(defaultName) },
+                    modifier = Modifier.weight(1f)
+                )
+            }
+
+            // Four sub-action dropdowns in a 2x2 grid. (none) is the
+            // first option so the rider can leave a slot empty — useful
+            // for groups with fewer than four actions. Packing two per
+            // row keeps the sheet from getting tall, and the labels on
+            // each field communicate which slot they map to.
+            val actionOptions = remember(viewModel) {
+                listOf("") + viewModel.knownDashboardActions
+            }
+            for (rowIdx in 0 until 2) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    for (col in 0 until 2) {
+                        val slotIdx = rowIdx * 2 + col
+                        ActionGroupSlotDropdown(
+                            label = stringResource(
+                                R.string.dashboard_group_action_slot,
+                                slotIdx + 1
+                            ),
+                            currentKey = actionSlots.getOrNull(slotIdx) ?: "",
+                            options = actionOptions,
+                            onSelect = { newKey ->
+                                actionSlots[slotIdx] = newKey
+                                persist()
+                            },
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+                }
+            }
+
+            SlotSheetFooter(onReset, onDismiss)
+            Spacer(Modifier.height(8.dp))
+        }
+    }
+}
+
+/**
+ * Square icon-button that shows the currently-chosen group/custom-tile
+ * icon. Tapping it pops a grid of curated icons; selecting one closes
+ * the popup. Lives next to the name OutlinedTextField in the edit sheet
+ * so the picker contributes zero extra vertical space — and scales to
+ * arbitrarily many icons via the popup's internal scroll.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun GroupIconButton(
+    currentKey: String,
+    onSelect: (String) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val outline = MaterialTheme.colorScheme.outline
+    Box {
+        // Anchor — matches OutlinedTextField height so the row aligns
+        // visually with the name field next to it.
+        Box(
+            modifier = Modifier
+                .size(56.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(MaterialTheme.colorScheme.surface)
+                .border(1.dp, outline, RoundedCornerShape(8.dp))
+                .clickable { expanded = true },
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                groupIconFor(currentKey),
+                contentDescription = null,
+                modifier = Modifier.size(26.dp),
+                tint = MaterialTheme.colorScheme.primary
+            )
+        }
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            modifier = Modifier.width(264.dp)
+        ) {
+            // 6-wide grid inside a fixed-width popup keeps icons square
+            // and visible without scrolling for the first ~30 icons.
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+                modifier = Modifier
+                    .padding(8.dp)
+                    .heightIn(max = 280.dp)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                GROUP_ICON_CHOICES.forEach { key ->
+                    val selected = key == currentKey
+                    val tint = if (selected) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.onSurfaceVariant
+                    val bg = if (selected) MaterialTheme.colorScheme.primaryContainer
+                        else MaterialTheme.colorScheme.surfaceVariant
+                    Box(
+                        modifier = Modifier
+                            .size(40.dp)
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(bg)
+                            .clickable {
+                                onSelect(key)
+                                expanded = false
+                            },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            groupIconFor(key),
+                            contentDescription = null,
+                            modifier = Modifier.size(22.dp),
+                            tint = tint
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Dropdown for picking a sub-action in the group edit sheet. Empty string
+ * means "no action assigned" and renders as a faint placeholder.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ActionGroupSlotDropdown(
+    label: String,
+    currentKey: String,
+    options: List<String>,
+    onSelect: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val noneLabel = stringResource(R.string.dashboard_group_action_none)
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = !expanded },
+        modifier = modifier
+    ) {
+        OutlinedTextField(
+            value = if (currentKey.isEmpty()) noneLabel else actionChipLabel(currentKey),
+            onValueChange = {},
+            readOnly = true,
+            singleLine = true,
+            label = { Text(label) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable, enabled = true)
+                .fillMaxWidth()
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            options.forEach { key ->
+                DropdownMenuItem(
+                    text = { Text(if (key.isEmpty()) noneLabel else actionChipLabel(key)) },
+                    onClick = {
+                        onSelect(key)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Edit sheet for a custom tile (rider's text + icon + optional tap action).
+ * Icon picker shares [GroupIconButton] with the action-group sheet so both
+ * sheets feel like one editor family. Action picker is a 3-item segmented
+ * control (None / URL / QR); the URL field only renders for the URL/QR
+ * choices so the sheet stays compact for plain text labels.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CustomTileSheet(
+    id: String,
+    settings: com.eried.eucplanet.data.model.AppSettings,
+    viewModel: SettingsViewModel,
+    onDismiss: () -> Unit,
+    onReset: () -> Unit
+) {
+    val tile = viewModel.getCustomTile(settings, id) ?: CustomTile()
+    val sheetState = rememberModalBottomSheetState()
+    var text by remember(id, tile.text) { mutableStateOf(tile.text) }
+    var icon by remember(id, tile.icon) { mutableStateOf(tile.icon) }
+    var action by remember(id, tile.action) { mutableStateOf(tile.action) }
+    var url by remember(id, tile.url) { mutableStateOf(tile.url) }
+
+    fun persist() = viewModel.updateCustomTile(id, text, icon, action, url)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 8.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            // Live tile preview using the rider's current draft values.
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(110.dp)
+                    .clip(RoundedCornerShape(14.dp))
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                    .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(14.dp))
+            ) {
+                CustomTileBody(
+                    tile = CustomTile(text = text, icon = icon, action = action, url = url)
+                )
+                actionBadgeIcon(action)?.let { badge ->
+                    Icon(
+                        badge,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.85f),
+                        modifier = Modifier
+                            .size(18.dp)
+                            .align(Alignment.BottomEnd)
+                            .padding(end = 8.dp, bottom = 6.dp)
+                    )
+                }
+            }
+
+            // Compact icon + text row. The icon button is sized to match the
+            // OutlinedTextField (56dp tall) and centred so the two controls
+            // read as one band — no top-edge drift.
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Box(
+                    modifier = Modifier.padding(top = 8.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    GroupIconButton(
+                        currentKey = icon,
+                        onSelect = {
+                            icon = it
+                            persist()
+                        }
+                    )
+                }
+                OutlinedTextField(
+                    value = text,
+                    onValueChange = {
+                        text = it
+                        persist()
+                    },
+                    singleLine = true,
+                    label = { Text(stringResource(R.string.dashboard_custom_tile_text_label)) },
+                    placeholder = {
+                        Text(stringResource(R.string.dashboard_custom_tile_text_placeholder))
+                    },
+                    modifier = Modifier.weight(1f)
+                )
+            }
+
+            // Three-way segmented control: Text (no action), Open URL,
+            // Show QR. NONE reads as "Text" because a custom tile with no
+            // action is just a label — the rider already named it via the
+            // text field above.
+            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                CustomTileAction.values().forEachIndexed { index, opt ->
+                    SegmentedButton(
+                        selected = action == opt,
+                        onClick = {
+                            action = opt
+                            persist()
+                        },
+                        shape = SegmentedButtonDefaults.itemShape(index, CustomTileAction.values().size),
+                        icon = {
+                            actionBadgeIcon(opt)?.let { v ->
+                                Icon(v, contentDescription = null, modifier = Modifier.size(16.dp))
+                            }
+                        }
+                    ) {
+                        Text(customTileActionLabel(opt))
+                    }
+                }
+            }
+
+            if (action != CustomTileAction.NONE) {
+                // Rotating placeholder so the rider sees a different social /
+                // donation / portfolio URL each time the sheet opens — keeps
+                // the field from feeling Instagram-only. MySpace shows up
+                // roughly 1-in-25 times as a nod to early-web nostalgia.
+                val placeholder = remember(id) { urlPlaceholderSample() }
+                OutlinedTextField(
+                    value = url,
+                    onValueChange = {
+                        url = it
+                        persist()
+                    },
+                    singleLine = true,
+                    label = { Text(stringResource(R.string.dashboard_custom_tile_url_label)) },
+                    placeholder = { Text(placeholder) },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+
+            SlotSheetFooter(onReset, onDismiss)
+            Spacer(Modifier.height(8.dp))
+        }
+    }
+}
+
+@Composable
+internal fun customTileActionLabel(action: CustomTileAction): String = when (action) {
+    CustomTileAction.NONE -> stringResource(R.string.dashboard_custom_tile_action_none)
+    CustomTileAction.OPEN_URL -> stringResource(R.string.dashboard_custom_tile_action_url)
+    CustomTileAction.SHOW_QR -> stringResource(R.string.dashboard_custom_tile_action_qr)
+}
+
+/**
+ * Picks a random URL sample for the custom-tile URL field placeholder so the
+ * rider sees a variety of services (social, donation, portfolio) instead of
+ * always-Instagram. MySpace is intentionally rare (~4%) as a nostalgic
+ * easter-egg for riders who'll catch the reference.
+ */
+private fun urlPlaceholderSample(): String {
+    val common = listOf(
+        "https://instagram.com/your-handle",
+        "https://x.com/your-handle",
+        "https://tiktok.com/@your-handle",
+        "https://youtube.com/@your-channel",
+        "https://patreon.com/your-handle",
+        "https://buymeacoffee.com/your-handle",
+        "https://ko-fi.com/your-handle",
+        "https://paypal.me/your-handle",
+        "https://github.com/your-handle",
+        "https://threads.net/@your-handle",
+        "https://reddit.com/u/your-handle",
+        "https://linkedin.com/in/your-handle",
+        "https://discord.gg/your-server",
+        "https://twitch.tv/your-channel"
+    )
+    // 4% chance to surface the MySpace easter egg.
+    return if (kotlin.random.Random.nextInt(25) == 0) {
+        "https://myspace.com/your-handle"
+    } else {
+        common.random()
+    }
+}
+
+@Composable
+private fun SlotSheetMetricPreview(
+    key: String,
+    stats: MetricSlotStats,
+    valueOf: () -> String,
+    onSparklineChange: (Boolean) -> Unit
+) {
+    val accent = metricAccentColor(key)
+    val label = metricChipLabel(key)
+    val value = valueOf()
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(140.dp)
+            .clip(RoundedCornerShape(14.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        if (stats.sparkline) {
+            WavePatternBackground(accent = accent, animated = true)
+        }
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            ThreeZoneRow(
+                metricLabel = label,
+                stats = stats,
+                value = value,
+                accent = accent,
+                centerBigSp = 30,
+                sideValueSp = 18,
+                sideLabelSp = 11,
+                metricLabelSp = 11
+            )
+        }
+        // The trend-background toggle lives on the artifact it controls: a
+        // small FilterChip in the top-right corner of the preview. When
+        // selected the chip fills with secondaryContainer and shows a check
+        // alongside the line-chart icon; when unselected it's outlined.
+        // Tapping toggles the wave background instantly.
+        FilterChip(
+            selected = stats.sparkline,
+            onClick = { onSparklineChange(!stats.sparkline) },
+            // Default Material typography so the label baseline aligns
+            // naturally with the leading icon — overriding fontSize here
+            // throws off the chip's internal centering.
+            label = { Text(stringResource(R.string.dashboard_slot_sparkline_chip)) },
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Filled.BarChart,
+                    contentDescription = stringResource(R.string.dashboard_slot_sparkline),
+                    modifier = Modifier.size(FilterChipDefaults.IconSize)
+                )
+            },
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                // Asymmetric inset: 2dp from the top so the chip hugs the
+                // upper edge, full 8dp on the right so it clears the
+                // rounded corner.
+                .padding(top = 2.dp, end = 8.dp)
+        )
+    }
+}
+
+/**
+ * Renders the three columns (left / center / right) for a metric tile.
+ *
+ * The metric name lives ONLY in the centre column's label area, so the rider
+ * always reads the tile's identity in the middle of the row. The centre stat
+ * itself shows its own label (NOW / MIN / MAX / AVG) above the metric name
+ * only when it's something other than the default CURRENT — that way the
+ * common case looks clean ("BATTERY" above the big value, no "NOW" clutter).
+ *
+ * Arrangement: when BOTH left and right are populated the row spreads with
+ * SpaceBetween so the values hug the edges; otherwise the row clusters in
+ * the centre and a single side reading still looks balanced.
+ */
+@Composable
+private fun ThreeZoneRow(
+    metricLabel: String,
+    stats: MetricSlotStats,
+    value: String,
+    accent: androidx.compose.ui.graphics.Color,
+    centerBigSp: Int,
+    sideValueSp: Int,
+    sideLabelSp: Int,
+    metricLabelSp: Int
+) {
+    val showLeft = stats.left != DashboardStat.NONE
+    val showRight = stats.right != DashboardStat.NONE
+
+    // Fixed three-column layout: the left column always sits at the left edge
+    // of the tile, right at the right edge, centre centred. Each badge's own
+    // text aligns with its column's outer edge so the side readings never
+    // drift toward the centre regardless of which combination is set.
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.Top
+    ) {
+        Box(
+            modifier = Modifier.weight(1f),
+            contentAlignment = Alignment.TopStart
+        ) {
+            if (showLeft) {
+                SideStatBadge(
+                    stat = stats.left,
+                    value = value,
+                    accent = accent,
+                    valueSp = sideValueSp,
+                    labelSp = sideLabelSp,
+                    align = Alignment.Start
+                )
+            }
+        }
+        Box(
+            modifier = Modifier.weight(1.2f),
+            contentAlignment = Alignment.TopCenter
+        ) {
+            CenterStatBadge(
+                stat = stats.center,
+                metricLabel = metricLabel,
+                value = value,
+                accent = accent,
+                centerBigSp = centerBigSp,
+                statLabelSp = sideLabelSp,
+                metricLabelSp = metricLabelSp
+            )
+        }
+        Box(
+            modifier = Modifier.weight(1f),
+            contentAlignment = Alignment.TopEnd
+        ) {
+            if (showRight) {
+                SideStatBadge(
+                    stat = stats.right,
+                    value = value,
+                    accent = accent,
+                    valueSp = sideValueSp,
+                    labelSp = sideLabelSp,
+                    align = Alignment.End
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SideStatBadge(
+    stat: DashboardStat,
+    value: String,
+    accent: androidx.compose.ui.graphics.Color,
+    valueSp: Int,
+    labelSp: Int,
+    align: Alignment.Horizontal
+) {
+    if (stat == DashboardStat.NONE) return
+    Column(horizontalAlignment = align) {
+        // Side labels share the centre label's typography (same font size +
+        // weight) so the row reads as one header line, with only the value
+        // below sized smaller than the centre one.
+        Text(
+            statShortLabel(stat),
+            fontSize = labelSp.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontWeight = FontWeight.Medium,
+            letterSpacing = 0.5.sp
+        )
+        Text(
+            value,
+            fontSize = valueSp.sp,
+            fontWeight = FontWeight.Bold,
+            color = accent,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+@Composable
+private fun CenterStatBadge(
+    stat: DashboardStat,
+    metricLabel: String,
+    value: String,
+    accent: androidx.compose.ui.graphics.Color,
+    centerBigSp: Int,
+    statLabelSp: Int,
+    metricLabelSp: Int
+) {
+    val showStatLabel = stat != DashboardStat.NONE && stat != DashboardStat.CURRENT
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        // Stat name appears only when the center is set to a non-default
+        // aggregation (MIN / MAX / AVG / MEDIAN / P95). It sits on the SAME
+        // row as the metric name so the header reads as one line ("MIN
+        // BATTERY") instead of stacked labels. The default "NOW" stays hidden
+        // since it'd be redundant alongside the big value.
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            if (showStatLabel) {
+                Text(
+                    statShortLabel(stat),
+                    fontSize = metricLabelSp.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontWeight = FontWeight.Medium,
+                    letterSpacing = 0.5.sp
+                )
+            }
+            Text(
+                metricLabel.uppercase(),
+                fontSize = metricLabelSp.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontWeight = FontWeight.Medium,
+                letterSpacing = 0.5.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+        if (stat != DashboardStat.NONE) {
+            Text(
+                value,
+                fontSize = centerBigSp.sp,
+                fontWeight = FontWeight.Bold,
+                color = accent,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}
+
+private fun statShortLabel(stat: DashboardStat): String = when (stat) {
+    DashboardStat.NONE -> ""
+    DashboardStat.CURRENT -> "NOW"
+    DashboardStat.MIN -> "MIN"
+    DashboardStat.MAX -> "MAX"
+    DashboardStat.SUSTAINED_PEAK -> "S.PK"
+    DashboardStat.AVG -> "AVG"
+    DashboardStat.MEDIAN -> "MED"
+    DashboardStat.P75 -> "P75"
+    DashboardStat.P95 -> "P95"
+    DashboardStat.P99 -> "P99"
+}
+
+/**
+ * One-or-two-line description of what a metric means. Rendered as a subtle
+ * info row above the side-readings dropdowns, only for metrics whose meaning
+ * isn't obvious from the chip label alone (the rest get null from
+ * [metricDescription]).
+ */
+@Composable
+private fun MetricInfoBox(text: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.Top
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Info,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+            modifier = Modifier.size(16.dp)
+        )
+        Spacer(Modifier.width(8.dp))
+        Text(
+            text,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontStyle = androidx.compose.ui.text.font.FontStyle.Italic
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SlotStatsEditor(
+    key: String,
+    stats: MetricSlotStats,
+    onCornerChange: (SlotCorner, DashboardStat) -> Unit
+) {
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        CornerStatDropdown(
+            modifier = Modifier.weight(1f),
+            label = stringResource(R.string.dashboard_corner_left),
+            value = stats.left,
+            onSelect = { onCornerChange(SlotCorner.LEFT, it) }
+        )
+        CornerStatDropdown(
+            modifier = Modifier.weight(1f),
+            label = stringResource(R.string.dashboard_corner_center),
+            value = stats.center,
+            onSelect = { onCornerChange(SlotCorner.CENTER, it) }
+        )
+        CornerStatDropdown(
+            modifier = Modifier.weight(1f),
+            label = stringResource(R.string.dashboard_corner_right),
+            value = stats.right,
+            onSelect = { onCornerChange(SlotCorner.RIGHT, it) }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun RollingWindowDropdown(
+    valueSeconds: Int,
+    onSelect: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val options = ROLLING_WINDOW_PRESETS_SECONDS
+    val current = options.firstOrNull { it == valueSeconds }
+        ?: options.minByOrNull { kotlin.math.abs(it - valueSeconds) }
+        ?: ROLLING_WINDOW_DEFAULT_SECONDS
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = !expanded },
+        modifier = modifier
+    ) {
+        OutlinedTextField(
+            value = rollingWindowLabel(current),
+            onValueChange = {},
+            readOnly = true,
+            singleLine = true,
+            label = { Text(stringResource(R.string.dashboard_stats_length)) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable, enabled = true)
+                .fillMaxWidth()
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            options.forEach { seconds ->
+                DropdownMenuItem(
+                    text = { Text(rollingWindowLabel(seconds)) },
+                    onClick = {
+                        onSelect(seconds)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+/**
+ * View selector: Default (2-column metric grid) vs Wide (3-column).
+ * On tablets/foldables the layout is force-Wide regardless of the rider's
+ * stored choice, so the field is shown locked to "Wide" and disabled.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ViewDropdown(
+    columns: Int,
+    forcedWide: Boolean,
+    onSelect: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val effectiveColumns = if (forcedWide) 3 else columns
+    val options = listOf(2, 3)
+    ExposedDropdownMenuBox(
+        expanded = expanded && !forcedWide,
+        onExpandedChange = { if (!forcedWide) expanded = !expanded },
+        modifier = modifier
+    ) {
+        OutlinedTextField(
+            value = viewLabel(effectiveColumns),
+            onValueChange = {},
+            readOnly = true,
+            enabled = !forcedWide,
+            singleLine = true,
+            label = { Text(stringResource(R.string.dashboard_view)) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded && !forcedWide) },
+            modifier = Modifier
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable, enabled = !forcedWide)
+                .fillMaxWidth()
+        )
+        ExposedDropdownMenu(
+            expanded = expanded && !forcedWide,
+            onDismissRequest = { expanded = false }
+        ) {
+            options.forEach { cols ->
+                DropdownMenuItem(
+                    text = { Text(viewLabel(cols)) },
+                    onClick = {
+                        onSelect(cols)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun viewLabel(columns: Int): String = when (columns) {
+    3 -> stringResource(R.string.dashboard_view_wide)
+    else -> stringResource(R.string.dashboard_view_default)
+}
+
+@Composable
+private fun rollingWindowLabel(seconds: Int): String = when (seconds) {
+    30 -> stringResource(R.string.dashboard_rolling_window_30s)
+    60 -> stringResource(R.string.dashboard_rolling_window_1m)
+    120 -> stringResource(R.string.dashboard_rolling_window_2m)
+    180 -> stringResource(R.string.dashboard_rolling_window_3m)
+    300 -> stringResource(R.string.dashboard_rolling_window_5m)
+    600 -> stringResource(R.string.dashboard_rolling_window_10m)
+    900 -> stringResource(R.string.dashboard_rolling_window_15m)
+    1800 -> stringResource(R.string.dashboard_rolling_window_30m)
+    3600 -> stringResource(R.string.dashboard_rolling_window_1h)
+    else -> "$seconds s"
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CornerStatDropdown(
+    modifier: Modifier,
+    label: String,
+    value: DashboardStat,
+    onSelect: (DashboardStat) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val options = remember { DashboardStat.values().toList() }
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = !expanded },
+        modifier = modifier
+    ) {
+        OutlinedTextField(
+            value = statSelectedLabel(value),
+            onValueChange = {},
+            readOnly = true,
+            singleLine = true,
+            label = { Text(label, fontSize = 10.sp) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable, enabled = true)
+                .fillMaxWidth()
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            options.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(statDisplayLabel(option)) },
+                    onClick = {
+                        onSelect(option)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Long, descriptive label shown for an option *inside* the open dropdown list
+ * (e.g. "99th percentile"). The user is browsing options here so verbose is
+ * fine and helps disambiguate.
+ */
+@Composable
+private fun statDisplayLabel(stat: DashboardStat): String = when (stat) {
+    DashboardStat.NONE -> stringResource(R.string.dashboard_stat_none)
+    DashboardStat.CURRENT -> stringResource(R.string.dashboard_stat_current)
+    DashboardStat.MIN -> stringResource(R.string.dashboard_stat_min)
+    DashboardStat.MAX -> stringResource(R.string.dashboard_stat_max)
+    DashboardStat.SUSTAINED_PEAK -> stringResource(R.string.dashboard_stat_sustained_peak)
+    DashboardStat.AVG -> stringResource(R.string.dashboard_stat_avg)
+    DashboardStat.MEDIAN -> stringResource(R.string.dashboard_stat_median)
+    DashboardStat.P75 -> stringResource(R.string.dashboard_stat_p75)
+    DashboardStat.P95 -> stringResource(R.string.dashboard_stat_p95)
+    DashboardStat.P99 -> stringResource(R.string.dashboard_stat_p99)
+}
+
+/**
+ * Compact label shown inside the dropdown field once an option is selected
+ * (e.g. "P99"). Stats whose long label is already short re-use it; percentiles
+ * collapse to their short form so the field doesn't wrap to two lines.
+ */
+@Composable
+private fun statSelectedLabel(stat: DashboardStat): String = when (stat) {
+    DashboardStat.NONE -> stringResource(R.string.dashboard_stat_none)
+    DashboardStat.CURRENT -> stringResource(R.string.dashboard_stat_current)
+    DashboardStat.MIN -> stringResource(R.string.dashboard_stat_min)
+    // MAX's long label is "Max / Peak"; in the closed dropdown field we use
+    // the bare "Max" to keep the row compact.
+    DashboardStat.MAX -> "Max"
+    DashboardStat.SUSTAINED_PEAK -> stringResource(R.string.dashboard_stat_sustained_peak_short)
+    DashboardStat.AVG -> stringResource(R.string.dashboard_stat_avg)
+    DashboardStat.MEDIAN -> stringResource(R.string.dashboard_stat_median_short)
+    DashboardStat.P75 -> stringResource(R.string.dashboard_stat_p75_short)
+    DashboardStat.P95 -> stringResource(R.string.dashboard_stat_p95_short)
+    DashboardStat.P99 -> stringResource(R.string.dashboard_stat_p99_short)
+}
+
+@Composable
+private fun SlotSheetActionPreview(key: String) {
+    val icon = dashboardActionIcon(key)
+    val label = actionChipLabel(key)
+    // Center a button-proportioned preview tile. Height matches the
+    // metric preview (140dp) for visual consistency between metric and
+    // action sheets; width preserves the live ActionTile aspect ratio
+    // (~120:86) so the rider still recognises this as a button rather
+    // than a metric card. Icon + label scale up proportionally.
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(140.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Box(
+            modifier = Modifier
+                .height(140.dp)
+                .aspectRatio(120f / 86f)
+                .clip(RoundedCornerShape(10.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .border(
+                    1.dp,
+                    MaterialTheme.colorScheme.outlineVariant,
+                    RoundedCornerShape(10.dp)
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(
+                modifier = Modifier.padding(horizontal = 8.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                if (icon != null) {
+                    Icon(
+                        icon,
+                        contentDescription = null,
+                        modifier = Modifier.size(42.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(Modifier.height(8.dp))
+                }
+                Text(
+                    label,
+                    fontSize = 16.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
+    }
+}
+
+// ---- Catalog look-up helpers (shared with the live dashboard) ----------
+//
+// All of these are `internal` so the eventual `com.eried.eucplanet.ui.dashboard`
+// renderer can call them directly — keeps a single source of truth for chip
+// labels, accent palette, action icons, etc. between the editor preview and
+// the live dashboard. Adding a new metric / action means updating one of
+// these tables, not two.
+
+/**
+ * Display label for a metric key. Reads from [com.eried.eucplanet.data.model.MetricCatalog]
+ * so adding a new metric is one entry in `MetricCatalog.all` — this
+ * function never needs to grow another branch. The composite-empty
+ * sentinel and unknown keys fall back to bespoke strings.
+ */
+@Composable
+internal fun metricChipLabel(key: String): String {
+    if (key == COMPOSITE_CELL_EMPTY) return stringResource(R.string.dashboard_composite_empty_label)
+    val spec = com.eried.eucplanet.data.model.MetricCatalog.byKey(key) ?: return key
+    return stringResource(spec.labelRes)
+}
+
+/**
+ * 1-2 sentence explanation surfaced in the slot-sheet info box for
+ * metrics whose meaning isn't obvious from the chip label. Pulls
+ * [com.eried.eucplanet.data.model.MetricSpec.descriptionRes] from the
+ * catalog — null when the metric has no description.
+ */
+@Composable
+internal fun metricDescription(key: String): String? {
+    val spec = com.eried.eucplanet.data.model.MetricCatalog.byKey(key) ?: return null
+    val resId = spec.descriptionRes ?: return null
+    return stringResource(resId)
+}
+
+/**
+ * Display label for an action key. Reads from [ActionCatalog] so adding
+ * a new action only needs a catalog entry — this function never needs to
+ * grow another branch.
+ */
+@Composable
+internal fun actionChipLabel(key: String): String {
+    val spec = com.eried.eucplanet.data.model.ActionCatalog.byKey(key)
+    return if (spec != null) stringResource(spec.labelRes) else key
+}
+
+/**
+ * True when min/max/avg/percentile stats are meaningful for this metric.
+ * Monotonic counters (`TRIP`, `ODOMETER`, accumulating trip-time/energy) and
+ * circular values (`GPS_HEADING`) return false — for those the pool pill
+ * shows no sparkline background at all, since "stats off" isn't a state the
+ * rider can toggle out of.
+ */
+/**
+ * True when min/max/avg/percentile stats are meaningful for this metric.
+ * Monotonic counters and circular values (GPS_HEADING) return false.
+ * Reads from [com.eried.eucplanet.data.model.MetricCatalog].
+ */
+internal fun metricSupportsStats(key: String): Boolean =
+    com.eried.eucplanet.data.model.MetricCatalog.byKey(key)?.supportsStats ?: true
+
+/**
+ * Accent palette for a metric — drives the value text + sparkline tint.
+ * Reads from [com.eried.eucplanet.data.model.MetricCatalog]; unknown keys
+ * (including the COMPOSITE_CELL_EMPTY sentinel) fall through to AccentBlue.
+ */
+internal fun metricAccentColor(key: String): androidx.compose.ui.graphics.Color =
+    com.eried.eucplanet.data.model.MetricCatalog.byKey(key)?.accent ?: AccentBlue
+
+/**
+ * Vector icon for an action key. Reads from [ActionCatalog] so adding a
+ * new action only needs a catalog entry. Returns null for unknown keys.
+ */
+internal fun dashboardActionIcon(key: String): ImageVector? =
+    com.eried.eucplanet.data.model.ActionCatalog.byKey(key)?.icon
+
+// Drag decoration shared by every draggable tile + pool pill in the dashboard
+// editor: a translucent rounded card the size of the source with an accent-
+// colored border, and the metric/action's own label + value (or icon + label
+// for actions) rendered on top so the rider can clearly see what's in their
+// hand mid-drag.
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawDashboardTileDecoration(
+    fill: androidx.compose.ui.graphics.Color,
+    accent: androidx.compose.ui.graphics.Color,
+    labelText: String,
+    valueText: String,
+    labelStyle: TextStyle,
+    valueStyle: TextStyle,
+    measurer: androidx.compose.ui.text.TextMeasurer
+) {
+    val cr = CornerRadius(10.dp.toPx())
+    drawRoundRect(color = fill.copy(alpha = 0.92f), cornerRadius = cr)
+    drawRoundRect(
+        color = accent,
+        cornerRadius = cr,
+        style = Stroke(width = 3.dp.toPx())
+    )
+
+    val labelResult = measurer.measure(labelText, labelStyle)
+    val gap = 2.dp.toPx()
+    if (valueText.isNotEmpty()) {
+        val valueResult = measurer.measure(valueText, valueStyle)
+        val totalH = labelResult.size.height + gap + valueResult.size.height
+        val startY = (size.height - totalH) / 2f
+        drawText(
+            labelResult,
+            topLeft = androidx.compose.ui.geometry.Offset(
+                x = (size.width - labelResult.size.width) / 2f,
+                y = startY
+            )
+        )
+        drawText(
+            valueResult,
+            topLeft = androidx.compose.ui.geometry.Offset(
+                x = (size.width - valueResult.size.width) / 2f,
+                y = startY + labelResult.size.height + gap
+            )
+        )
+    } else {
+        drawText(
+            labelResult,
+            topLeft = androidx.compose.ui.geometry.Offset(
+                x = (size.width - labelResult.size.width) / 2f,
+                y = (size.height - labelResult.size.height) / 2f
+            )
+        )
+    }
+}
+
+// Stylized "histogram" wave drawn behind the tile when the rider has the
+// trend background toggled on. Rendered as 30 horizontal step segments at
+// quantised sine heights so it reads as a stepped sparkline rather than a
+// smooth curve — matches the rhythm of real 1Hz dashboard samples connected
+// by straight segments. When [animated] is true the wave's phase shifts over
+// time so the staircase visibly scrolls; used in the bottom-sheet preview to
+// hint that this is a *live* trend feature, while the small grid tiles stay
+// static so the grid itself doesn't feel restless.
+@Composable
+private fun WavePatternBackground(
+    accent: androidx.compose.ui.graphics.Color,
+    modifier: Modifier = Modifier,
+    animated: Boolean = false,
+    steps: Int = 30,
+    /**
+     * When `true`, renders the wave at a much fainter alpha so it reads as
+     * "stats are available but disabled — tap to re-enable" instead of an
+     * active sparkline. Used by the pool pills to distinguish disabled
+     * metrics from those that don't support stats at all (the latter omit
+     * the background entirely).
+     */
+    dimmed: Boolean = false
+) {
+    val phase: Float = if (animated) {
+        val transition = rememberInfiniteTransition(label = "wave")
+        val v by transition.animateFloat(
+            initialValue = 0f,
+            targetValue = (2.0 * kotlin.math.PI).toFloat(),
+            animationSpec = infiniteRepeatable(
+                animation = tween(durationMillis = 4500, easing = LinearEasing)
+            ),
+            label = "wave-phase"
+        )
+        v
+    } else {
+        0f
+    }
+    Canvas(modifier = modifier.fillMaxSize()) {
+        val cycles = 2.0
+        val amplitude = size.height * 0.22f
+        val centerY = size.height / 2f
+        val stepW = size.width / steps.toFloat()
+        val path = Path()
+        // Build the staircase: each step is a horizontal segment whose Y is
+        // sampled from a sine at the step's midpoint. Connecting segments are
+        // straight vertical drops so the line reads as discrete columns.
+        for (i in 0 until steps) {
+            val midT = (i.toFloat() + 0.5f) / steps
+            val sineArg = midT * cycles * 2.0 * kotlin.math.PI - phase
+            val sineVal = kotlin.math.sin(sineArg).toFloat()
+            val y = centerY - sineVal * amplitude
+            val x0 = i * stepW
+            val x1 = (i + 1) * stepW
+            if (i == 0) path.moveTo(x0, y) else path.lineTo(x0, y)
+            path.lineTo(x1, y)
+        }
+        // Soft filled area under the staircase for the StatCard-style gradient.
+        val fillPath = Path()
+        fillPath.addPath(path)
+        fillPath.lineTo(size.width, size.height)
+        fillPath.lineTo(0f, size.height)
+        fillPath.close()
+        // Kept deliberately faint so the readings stay the focus — the wave
+        // is a hint, not a chart. The dimmed variant fades further so a
+        // "disabled but available" wave reads as a ghost behind the pill.
+        val fillAlpha = if (dimmed) 0.015f else 0.04f
+        val strokeAlpha = if (dimmed) 0.06f else 0.18f
+        drawPath(fillPath, color = accent.copy(alpha = fillAlpha))
+        drawPath(path, color = accent.copy(alpha = strokeAlpha), style = Stroke(width = 1.5.dp.toPx()))
+    }
+}
+
+// Deterministic per-metric sparkline silhouette so the preview tiles aren't
+// empty rectangles. Each metric gets a stable shape derived from its key.
+private fun syntheticSpark(key: String): List<Float> {
+    val seed = key.hashCode().toLong()
+    val rng = java.util.Random(seed)
+    return List(24) { rng.nextFloat() }
+}
+
+/** Swaps `draggedKey` with whatever currently sits at `targetSlotIndex` so the
+ *  grid can render a mid-drag tentative order. Real persistence happens on
+ *  drop via the ViewModel — this is purely visual. */
+private fun previewSwap(order: List<String>, draggedKey: String, targetSlotIndex: Int): List<String> {
+    val items = order.toMutableList()
+    val from = items.indexOf(draggedKey)
+    if (from < 0 || targetSlotIndex !in items.indices || from == targetSlotIndex) return order
+    val a = items[from]
+    items[from] = items[targetSlotIndex]
+    items[targetSlotIndex] = a
+    return items
+}
+
+/**
+ * Placeholder reading for a not-yet-connected metric in the editor preview.
+ * Always uses zero as the value but appends the correct unit so the rider
+ * sees how the tile will read on a live ride. Respects the rider's selected
+ * speed / distance / temperature units from [AppSettings].
+ */
+private fun metricPlaceholderValue(
+    key: String,
+    s: com.eried.eucplanet.data.model.AppSettings
+): String = when (key) {
+    "BATTERY", "BATTERY_1", "BATTERY_2", "LOAD" -> "0%"
+    "TEMPERATURE" -> if (s.unitTemp == "F") "0°F" else "0°C"
+    "VOLTAGE" -> "0 V"
+    "CURRENT", "DYN_CURRENT_LIMIT" -> "0 A"
+    "POWER", "MOTOR_POWER", "BATTERY_POWER" -> "0 W"
+    "TRIP", "ODOMETER" -> when (s.unitDistance) {
+        "mi" -> "0 mi"
+        "mil" -> "0 mil"
+        else -> "0 km"
+    }
+    "SPEED", "DYN_SPEED_LIMIT" -> when (s.unitSpeed) {
+        "mph" -> "0 mph"
+        "kn" -> "0 kn"
+        else -> "0 km/h"
+    }
+    "PITCH", "ROLL" -> "0°"
+    "G_FORCE", "LATERAL_G", "FORWARD_G" -> "0.0 g"
+    "TORQUE" -> "0 Nm"
+    "MOTOR_TEMP", "CONTROLLER_TEMP", "BATTERY_TEMP" ->
+        if (s.unitTemp == "F") "0°F" else "0°C"
+    "HEADROOM", "TRIP_MAX_SPEED", "AVG_TRIP_SPEED", "GPS_SPEED" -> when (s.unitSpeed) {
+        "mph" -> "0 mph"
+        "kn" -> "0 kn"
+        else -> "0 km/h"
+    }
+    "TRIP_TIME" -> "0:00"
+    "WH_CONSUMED" -> "0 Wh"
+    "RANGE_ESTIMATE" -> when (s.unitDistance) {
+        "mi" -> "0 mi"
+        "mil" -> "0 mil"
+        else -> "0 km"
+    }
+    "WH_PER_KM" -> when (s.unitDistance) {
+        "mi" -> "0 Wh/mi"
+        "mil" -> "0 Wh/mil"
+        else -> "0 Wh/km"
+    }
+    "PHONE_BATTERY" -> "0%"
+    "GPS_ALTITUDE" -> if (s.unitDistance == "mi") "0 ft" else "0 m"
+    "GPS_HEADING" -> "0°"
+    "GPS_ACCURACY" -> if (s.unitDistance == "mi") "0 ft" else "0 m"
+    "SLOPE" -> "0 %"
+    "ASCENT", "DESCENT" -> if (s.unitDistance == "mi") "0 ft" else "0 m"
+    "MOTOR_RPM" -> "0 rpm"
+    "REGEN_WH" -> "0 Wh"
+    "BT_RSSI" -> "0 dBm"
+    // EMPTY cell renders no value — the cell composable already shows the
+    // "(empty)" placeholder text via the chip-label path instead.
+    COMPOSITE_CELL_EMPTY -> ""
+    else -> "--"
 }
 
 // --- Display Tab ---
@@ -1697,8 +5459,20 @@ private fun WatchActionPicker(
     currentKey: String,
     onSelect: (String) -> Unit
 ) {
-    val options = com.eried.eucplanet.data.model.FlicAction.entries.map { action ->
-        action.name to stringResource(action.labelRes)
+    // Watch can bind eyes-free actions only. A synthetic "None" first
+    // option lets the rider clear the binding.
+    val noneLabel = stringResource(R.string.flic_action_none)
+    val keys = remember {
+        com.eried.eucplanet.data.model.ActionCatalog.keysFor(
+            com.eried.eucplanet.data.model.ActionSurface.WATCH
+        )
+    }
+    val options = buildList {
+        add("NONE" to noneLabel)
+        keys.forEach { key ->
+            val spec = com.eried.eucplanet.data.model.ActionCatalog.byKey(key) ?: return@forEach
+            add(key to stringResource(spec.labelRes))
+        }
     }
     SimpleDropdown(
         label = label,
@@ -2982,10 +6756,16 @@ private fun ActionDropdown(
     onValueChange: (String) -> Unit
 ) {
     var expanded by remember { mutableStateOf(false) }
-    val currentAction = try {
-        FlicAction.valueOf(currentValue)
-    } catch (_: Exception) {
-        FlicAction.NONE
+    val volumeKeys = remember {
+        com.eried.eucplanet.data.model.ActionCatalog.keysFor(
+            com.eried.eucplanet.data.model.ActionSurface.VOLUME_KEY
+        )
+    }
+    val noneLabel = stringResource(R.string.flic_action_none)
+    val currentLabel = when {
+        currentValue.isEmpty() || currentValue == "NONE" -> noneLabel
+        else -> com.eried.eucplanet.data.model.ActionCatalog.byKey(currentValue)
+            ?.labelRes?.let { stringResource(it) } ?: noneLabel
     }
 
     ExposedDropdownMenuBox(
@@ -2993,7 +6773,7 @@ private fun ActionDropdown(
         onExpandedChange = { expanded = !expanded }
     ) {
         OutlinedTextField(
-            value = stringResource(currentAction.labelRes),
+            value = currentLabel,
             onValueChange = {},
             readOnly = true,
             label = { Text(highlightMatches(label, LocalSettingsSearchQuery.current)) },
@@ -3006,11 +6786,19 @@ private fun ActionDropdown(
             expanded = expanded,
             onDismissRequest = { expanded = false }
         ) {
-            FlicAction.entries.forEach { action ->
+            DropdownMenuItem(
+                text = { Text(noneLabel) },
+                onClick = {
+                    onValueChange("NONE")
+                    expanded = false
+                }
+            )
+            volumeKeys.forEach { key ->
+                val spec = com.eried.eucplanet.data.model.ActionCatalog.byKey(key) ?: return@forEach
                 DropdownMenuItem(
-                    text = { Text(stringResource(action.labelRes)) },
+                    text = { Text(stringResource(spec.labelRes)) },
                     onClick = {
-                        onValueChange(action.name)
+                        onValueChange(key)
                         expanded = false
                     }
                 )

--- a/app/src/main/java/com/eried/eucplanet/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/eried/eucplanet/ui/settings/SettingsViewModel.kt
@@ -475,10 +475,1106 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
+    // ---- Dashboard layout (catalog model) ----
+    //
+    // Mental model:
+    //   - knownDashboardMetrics / knownDashboardActions are the CATALOG: every
+    //     static key the dashboard knows about. The pool in the layout editor
+    //     renders this list alphabetically (sorted by display label).
+    //   - dashboardMetricOrder / dashboardActionOrder are the GRID: the first
+    //     ACTIVE_DASHBOARD_TILE_COUNT entries are what the rider sees on the
+    //     active dashboard. The catalog stays full regardless.
+    //   - Dynamic instances (`M:uuid` composites, `C:uuid` custom tiles,
+    //     `G:uuid` action groups) only live in the grid order, never the
+    //     catalog. Templates (+MULTI / +GROUP) spawn fresh instances when
+    //     dragged onto a slot.
+    //
+    // Drag semantics (DashboardDragController.sourceFromGrid drives the branch):
+    //   - Grid → grid (sourceFromGrid=true): SWAP via moveDashboard*ToIndex
+    //   - Pool → grid (sourceFromGrid=false): COPY via setDashboard*AtIndex
+    //     (catalog stays full; displaced grid tile is discarded)
+    //   - Grid → pool: discard. Dynamic → delete definition. Static metric →
+    //     demote (slot becomes empty custom tile). Static action → no-op
+    //     (catalog always has it; rider uses Restore slot for default).
+    //
+    // To add a new metric:
+    //   1. Append its key to knownDashboardMetrics below.
+    //   2. Add a label entry in SettingsScreen.kt::metricChipLabel and an
+    //      optional description in metricDescription.
+    //   3. Add a placeholder/value in metricPlaceholderValue.
+    //   4. Optionally an accent color in metricAccentColor and stats support
+    //      flag in metricSupportsStats.
+    //   5. When the dashboard renderer (DashboardScreen.kt) is wired in
+    //      phase 2, also surface the metric there.
+    //
+    // To add a new ACTION: see the comment on knownDashboardActions below —
+    // multiple files need touching because Flic / volume keys / WearOS have
+    // their own definitions today (see audit comment there).
+    //
+    // Saved orders are sanitized against the catalog so unknown tokens
+    // (renames, removals) drop silently and newly-added entries appear at
+    // the end of the order on first read.
+    val knownDashboardMetrics = listOf(
+        // Currently active by default — keep these 6 first so a fresh install
+        // mirrors the hard-coded layout byte-for-byte.
+        "BATTERY", "TEMPERATURE", "VOLTAGE", "CURRENT", "LOAD", "TRIP",
+        // Pool — already-buffered or simple-to-derive metrics.
+        "SPEED", "POWER", "ODOMETER",
+        "MOTOR_POWER", "BATTERY_POWER",
+        "BATTERY_1", "BATTERY_2",
+        "PITCH", "ROLL",
+        "G_FORCE", "LATERAL_G", "FORWARD_G",
+        "TORQUE", "DYN_SPEED_LIMIT", "DYN_CURRENT_LIMIT",
+        // Individual temperature sensors (WheelData.temperatures by index).
+        "MOTOR_TEMP", "CONTROLLER_TEMP", "BATTERY_TEMP",
+        // Derived trip metrics (computed from speed/voltage/current histories
+        // once Phase 3 aggregation lands).
+        "HEADROOM", "TRIP_TIME", "TRIP_MAX_SPEED", "AVG_TRIP_SPEED",
+        "WH_CONSUMED", "RANGE_ESTIMATE", "WH_PER_KM",
+        // Phone + GPS feeds — sourced outside WheelData.
+        "PHONE_BATTERY", "GPS_ALTITUDE", "GPS_SPEED", "GPS_HEADING",
+        "GPS_ACCURACY",
+        // Derived motion + pack health — slope/altitude integration and
+        // wheel-firmware fields some boards expose.
+        "SLOPE", "ASCENT", "DESCENT", "MOTOR_RPM", "REGEN_WH",
+        // Connectivity diagnostic — useful when debugging dropouts.
+        "BT_RSSI"
+    )
+    /**
+     * Dashboard-eligible actions, derived from [ActionCatalog]. Adding a
+     * new action is a single entry in `ActionCatalog.all` — no edit here.
+     *
+     * The dashboard surface accepts every action regardless of
+     * [ActionSpec.isEyesFreeSafe]; physical surfaces (Flic / volume key /
+     * watch) filter via [ActionCatalog.keysFor]. See ActionCatalog.kt for
+     * the full design.
+     */
+    val knownDashboardActions: List<String> =
+        com.eried.eucplanet.data.model.ActionCatalog.keysFor(
+            com.eried.eucplanet.data.model.ActionSurface.DASHBOARD
+        )
+
+    private fun sanitize(
+        saved: String,
+        known: List<String>,
+        dynamic: Set<String> = emptySet()
+    ): List<String> {
+        val s = saved.split(",")
+            .map { it.trim() }
+            .filter { it.isNotEmpty() && (it in known || it in dynamic) }
+        // Append known keys that aren't already in the saved order so the pool
+        // surfaces new defaults after an app upgrade. Dynamic IDs are NOT
+        // auto-added — they only exist while the rider has them on the grid
+        // or until they delete the underlying composite/group definition.
+        return s + known.filter { it !in s }
+    }
+
+    fun dashboardMetricOrder(s: AppSettings): List<String> =
+        sanitize(
+            s.dashboardMetricOrder,
+            knownDashboardMetrics,
+            listCompositeMetrics(s).keys + listCustomTiles(s).keys
+        )
+    fun dashboardActionOrder(s: AppSettings): List<String> =
+        sanitize(s.dashboardActionOrder, knownDashboardActions, listActionGroups(s).keys)
+
+    // --- Composite metrics (multi-cell tiles) -----------------------------
+    //
+    // A composite is one grid tile that stacks 2 or 3 sub-metric current
+    // values in a chosen layout. Definitions live in [AppSettings.
+    // dashboardCompositeMetrics] keyed by `M:<uuid>` so the rider can have
+    // several composite instances on the grid simultaneously. The same ID
+    // appears in [AppSettings.dashboardMetricOrder] to position the tile.
+
+    fun listCompositeMetrics(s: AppSettings): Map<String, MetricComposite> {
+        val root = parseSlotStatsRoot(s.dashboardCompositeMetrics)
+        val out = LinkedHashMap<String, MetricComposite>()
+        val it = root.keys()
+        while (it.hasNext()) {
+            val id = it.next()
+            val node = root.optJSONObject(id) ?: continue
+            val layout = runCatching {
+                CompositeLayout.valueOf(node.optString("layout", CompositeLayout.ROW2.name))
+            }.getOrDefault(CompositeLayout.ROW2)
+            val cellsArr = node.optJSONArray("cells")
+            val cells = if (cellsArr != null) {
+                (0 until cellsArr.length()).mapNotNull { cellsArr.optString(it).takeIf { s -> s.isNotEmpty() } }
+            } else emptyList()
+            // Parallel "cellStats" array. Missing entries (older composites
+            // saved before per-cell stats existed) default to CURRENT so
+            // the rider's prior layout keeps looking the same.
+            val statsArr = node.optJSONArray("cellStats")
+            val cellStats: List<DashboardStat> = if (statsArr != null) {
+                (0 until statsArr.length()).map { idx ->
+                    runCatching {
+                        DashboardStat.valueOf(statsArr.optString(idx, DashboardStat.CURRENT.name))
+                    }.getOrDefault(DashboardStat.CURRENT)
+                }
+            } else List(cells.size) { DashboardStat.CURRENT }
+            out[id] = MetricComposite(layout, cells, cellStats)
+        }
+        return out
+    }
+
+    fun getCompositeMetric(s: AppSettings, id: String): MetricComposite? = listCompositeMetrics(s)[id]
+
+    /**
+     * Creates a new composite-metric instance with default content, inserts
+     * its ID into [AppSettings.dashboardMetricOrder] at [insertAtIndex] (and
+     * drops whatever previously occupied that slot back to the pool), and
+     * returns the new ID so the caller can route the rider into the edit
+     * sheet.
+     */
+    fun createCompositeMetricAt(insertAtIndex: Int): String {
+        val newId = "${COMPOSITE_METRIC_PREFIX}${java.util.UUID.randomUUID().toString().take(8)}"
+        viewModelScope.launch {
+            val current = settingsRepository.get()
+            val root = parseSlotStatsRoot(current.dashboardCompositeMetrics)
+            val node = org.json.JSONObject()
+                .put("layout", CompositeLayout.ROW2.name)
+                .put("cells", org.json.JSONArray(listOf("SPEED", "BATTERY")))
+            root.put(newId, node)
+
+            // Insert into the order at the target index, replacing whatever
+            // was there. The displaced key is appended so it doesn't vanish.
+            val order = sanitize(
+                current.dashboardMetricOrder,
+                knownDashboardMetrics,
+                root.keys().asSequence().toSet()
+            ).toMutableList()
+            val safeIdx = insertAtIndex.coerceIn(0, order.size)
+            if (safeIdx < order.size) {
+                val displaced = order.removeAt(safeIdx)
+                order.add(safeIdx, newId)
+                order.add(displaced)
+            } else {
+                order.add(newId)
+            }
+
+            settingsRepository.update(
+                current.copy(
+                    dashboardCompositeMetrics = root.toString(),
+                    dashboardMetricOrder = order.joinToString(",")
+                )
+            )
+        }
+        return newId
+    }
+
+    fun updateCompositeMetric(
+        id: String,
+        layout: CompositeLayout,
+        cells: List<String>,
+        cellStats: List<DashboardStat> = List(cells.size) { DashboardStat.CURRENT }
+    ) {
+        viewModelScope.launch {
+            val current = settingsRepository.get()
+            val root = parseSlotStatsRoot(current.dashboardCompositeMetrics)
+            val node = root.optJSONObject(id) ?: org.json.JSONObject()
+            node.put("layout", layout.name)
+            val truncatedCells = cells.take(layout.cellCount)
+            val truncatedStats = cellStats.take(layout.cellCount).let { existing ->
+                // Pad with CURRENT if the rider widened the layout before
+                // picking a stat for the new cell.
+                if (existing.size >= truncatedCells.size) existing
+                else existing + List(truncatedCells.size - existing.size) { DashboardStat.CURRENT }
+            }
+            node.put("cells", org.json.JSONArray(truncatedCells))
+            node.put("cellStats", org.json.JSONArray(truncatedStats.map { it.name }))
+            root.put(id, node)
+            settingsRepository.update(current.copy(dashboardCompositeMetrics = root.toString()))
+        }
+    }
+
+    fun deleteCompositeMetric(id: String) {
+        viewModelScope.launch {
+            val current = settingsRepository.get()
+            val root = parseSlotStatsRoot(current.dashboardCompositeMetrics)
+            root.remove(id)
+            val order = current.dashboardMetricOrder
+                .split(",")
+                .map { it.trim() }
+                .filter { it.isNotEmpty() && it != id }
+                .joinToString(",")
+            settingsRepository.update(
+                current.copy(
+                    dashboardCompositeMetrics = root.toString(),
+                    dashboardMetricOrder = order
+                )
+            )
+        }
+    }
+
+    // --- Action groups (one button → popover with N sub-actions) ----------
+
+    fun listActionGroups(s: AppSettings): Map<String, ActionGroup> {
+        val root = parseSlotStatsRoot(s.dashboardActionGroups)
+        val out = LinkedHashMap<String, ActionGroup>()
+        val it = root.keys()
+        while (it.hasNext()) {
+            val id = it.next()
+            val node = root.optJSONObject(id) ?: continue
+            val name = node.optString("name", "")
+            val icon = node.optString("icon", GROUP_DEFAULT_ICON).ifEmpty { GROUP_DEFAULT_ICON }
+            val arr = node.optJSONArray("actions")
+            val actions = if (arr != null) {
+                (0 until arr.length()).mapNotNull { arr.optString(it).takeIf { s -> s.isNotEmpty() } }
+            } else emptyList()
+            out[id] = ActionGroup(name = name, icon = icon, actions = actions)
+        }
+        return out
+    }
+
+    fun getActionGroup(s: AppSettings, id: String): ActionGroup? = listActionGroups(s)[id]
+
+    fun createActionGroupAt(insertAtIndex: Int): String {
+        val newId = "${ACTION_GROUP_PREFIX}${java.util.UUID.randomUUID().toString().take(8)}"
+        viewModelScope.launch {
+            val current = settingsRepository.get()
+            val root = parseSlotStatsRoot(current.dashboardActionGroups)
+            val node = org.json.JSONObject()
+                .put("name", "")
+                .put("icon", GROUP_DEFAULT_ICON)
+                .put("actions", org.json.JSONArray(emptyList<String>()))
+            root.put(newId, node)
+
+            val order = sanitize(
+                current.dashboardActionOrder,
+                knownDashboardActions,
+                root.keys().asSequence().toSet()
+            ).toMutableList()
+            val safeIdx = insertAtIndex.coerceIn(0, order.size)
+            if (safeIdx < order.size) {
+                val displaced = order.removeAt(safeIdx)
+                order.add(safeIdx, newId)
+                order.add(displaced)
+            } else {
+                order.add(newId)
+            }
+
+            settingsRepository.update(
+                current.copy(
+                    dashboardActionGroups = root.toString(),
+                    dashboardActionOrder = order.joinToString(",")
+                )
+            )
+        }
+        return newId
+    }
+
+    fun updateActionGroup(id: String, name: String, icon: String, actions: List<String>) {
+        viewModelScope.launch {
+            val current = settingsRepository.get()
+            val root = parseSlotStatsRoot(current.dashboardActionGroups)
+            val node = root.optJSONObject(id) ?: org.json.JSONObject()
+            node.put("name", name)
+            node.put("icon", icon.ifEmpty { GROUP_DEFAULT_ICON })
+            node.put("actions", org.json.JSONArray(actions.take(4)))
+            root.put(id, node)
+            settingsRepository.update(current.copy(dashboardActionGroups = root.toString()))
+        }
+    }
+
+    fun deleteActionGroup(id: String) {
+        viewModelScope.launch {
+            val current = settingsRepository.get()
+            val root = parseSlotStatsRoot(current.dashboardActionGroups)
+            root.remove(id)
+            val order = current.dashboardActionOrder
+                .split(",")
+                .map { it.trim() }
+                .filter { it.isNotEmpty() && it != id }
+                .joinToString(",")
+            settingsRepository.update(
+                current.copy(
+                    dashboardActionGroups = root.toString(),
+                    dashboardActionOrder = order
+                )
+            )
+        }
+    }
+
+    // --- Custom tiles (rider text + icon + optional URL / QR action) ----
+
+    fun listCustomTiles(s: AppSettings): Map<String, CustomTile> {
+        val root = parseSlotStatsRoot(s.dashboardCustomTiles)
+        val out = LinkedHashMap<String, CustomTile>()
+        val it = root.keys()
+        while (it.hasNext()) {
+            val id = it.next()
+            val node = root.optJSONObject(id) ?: continue
+            val text = node.optString("text", "")
+            val icon = node.optString("icon", CUSTOM_TILE_DEFAULT_ICON).ifEmpty { CUSTOM_TILE_DEFAULT_ICON }
+            val action = runCatching {
+                CustomTileAction.valueOf(node.optString("action", CustomTileAction.NONE.name))
+            }.getOrDefault(CustomTileAction.NONE)
+            val url = node.optString("url", "")
+            out[id] = CustomTile(text = text, icon = icon, action = action, url = url)
+        }
+        return out
+    }
+
+    fun getCustomTile(s: AppSettings, id: String): CustomTile? = listCustomTiles(s)[id]
+
+    fun createCustomTileAt(insertAtIndex: Int): String {
+        val newId = "${CUSTOM_TILE_PREFIX}${java.util.UUID.randomUUID().toString().take(8)}"
+        viewModelScope.launch {
+            val current = settingsRepository.get()
+            val root = parseSlotStatsRoot(current.dashboardCustomTiles)
+            val node = org.json.JSONObject()
+                .put("text", "")
+                .put("icon", CUSTOM_TILE_DEFAULT_ICON)
+                .put("action", CustomTileAction.NONE.name)
+                .put("url", "")
+            root.put(newId, node)
+
+            val order = sanitize(
+                current.dashboardMetricOrder,
+                knownDashboardMetrics,
+                listCompositeMetrics(current).keys + root.keys().asSequence().toSet()
+            ).toMutableList()
+            val safeIdx = insertAtIndex.coerceIn(0, order.size)
+            if (safeIdx < order.size) {
+                val displaced = order.removeAt(safeIdx)
+                order.add(safeIdx, newId)
+                order.add(displaced)
+            } else {
+                order.add(newId)
+            }
+
+            settingsRepository.update(
+                current.copy(
+                    dashboardCustomTiles = root.toString(),
+                    dashboardMetricOrder = order.joinToString(",")
+                )
+            )
+        }
+        return newId
+    }
+
+    fun updateCustomTile(id: String, text: String, icon: String, action: CustomTileAction, url: String) {
+        viewModelScope.launch {
+            val current = settingsRepository.get()
+            val root = parseSlotStatsRoot(current.dashboardCustomTiles)
+            val node = root.optJSONObject(id) ?: org.json.JSONObject()
+            node.put("text", text)
+            node.put("icon", icon.ifEmpty { CUSTOM_TILE_DEFAULT_ICON })
+            node.put("action", action.name)
+            node.put("url", url)
+            root.put(id, node)
+            settingsRepository.update(current.copy(dashboardCustomTiles = root.toString()))
+        }
+    }
+
+    /**
+     * Demotes an active-grid metric to the pool and spawns a new empty
+     * custom tile in the slot it vacated. The rider then taps the new tile
+     * to fill in their text / URL / QR. No-op when [metricKey] isn't in the
+     * active portion of the grid — dragging a pool pill back to the pool
+     * shouldn't create custom tiles.
+     */
+    fun demoteMetricToCustomTile(metricKey: String) {
+        viewModelScope.launch {
+            val current = settingsRepository.get()
+            val items = sanitize(
+                current.dashboardMetricOrder,
+                knownDashboardMetrics,
+                listCompositeMetrics(current).keys + listCustomTiles(current).keys
+            ).toMutableList()
+            val activeCount = ACTIVE_DASHBOARD_TILE_COUNT
+            val idx = items.indexOf(metricKey)
+            if (idx < 0 || idx >= activeCount) return@launch
+
+            // Create the new custom tile with defaults; rider edits it via tap.
+            val newId = "${CUSTOM_TILE_PREFIX}${java.util.UUID.randomUUID().toString().take(8)}"
+            val root = parseSlotStatsRoot(current.dashboardCustomTiles)
+            val node = org.json.JSONObject()
+                .put("text", "")
+                .put("icon", CUSTOM_TILE_DEFAULT_ICON)
+                .put("action", CustomTileAction.NONE.name)
+                .put("url", "")
+            root.put(newId, node)
+
+            // Swap: new custom tile takes the vacated slot, demoted metric
+            // appends to the end (lands in the pool because it's past
+            // activeCount in the order list).
+            items[idx] = newId
+            items.add(metricKey)
+
+            settingsRepository.update(
+                current.copy(
+                    dashboardCustomTiles = root.toString(),
+                    dashboardMetricOrder = items.joinToString(",")
+                )
+            )
+        }
+    }
+
+    fun deleteCustomTile(id: String) {
+        viewModelScope.launch {
+            val current = settingsRepository.get()
+            val root = parseSlotStatsRoot(current.dashboardCustomTiles)
+            root.remove(id)
+            val order = current.dashboardMetricOrder
+                .split(",")
+                .map { it.trim() }
+                .filter { it.isNotEmpty() && it != id }
+                .joinToString(",")
+            settingsRepository.update(
+                current.copy(
+                    dashboardCustomTiles = root.toString(),
+                    dashboardMetricOrder = order
+                )
+            )
+        }
+    }
+
+    /**
+     * Catalog-model copy: write [key] into grid slot [slotIndex], leaving
+     * the pool catalog untouched. Used when the drag source is a pool
+     * pill (i.e. `sourceFromGrid = false` on the controller). Whatever
+     * was at [slotIndex] is discarded — for dynamic instances (composite
+     * / custom tile) the definition is deleted too. The displaced static
+     * metric is NOT added to the pool because the pool is the always-
+     * present catalog of known metrics.
+     */
+    fun setDashboardMetricAtIndex(key: String, slotIndex: Int) {
+        viewModelScope.launch {
+            val current = settingsRepository.get()
+            val items = sanitize(
+                current.dashboardMetricOrder,
+                knownDashboardMetrics,
+                listCompositeMetrics(current).keys + listCustomTiles(current).keys
+            ).toMutableList()
+            if (slotIndex !in 0 until ACTIVE_DASHBOARD_TILE_COUNT) return@launch
+            if (slotIndex !in items.indices) return@launch
+            val displaced = items[slotIndex]
+            if (displaced == key) return@launch
+
+            // Replace the slot with the new key.
+            items[slotIndex] = key
+            // If the displaced was a dynamic instance, drop its order
+            // entry past the active region too (it's getting deleted).
+            if (isCompositeMetricKey(displaced) || isCustomTileKey(displaced)) {
+                items.removeAll { it == displaced }
+            }
+
+            val newComposites = if (isCompositeMetricKey(displaced))
+                parseSlotStatsRoot(current.dashboardCompositeMetrics)
+                    .also { it.remove(displaced) }.toString()
+            else current.dashboardCompositeMetrics
+            val newCustomTiles = if (isCustomTileKey(displaced))
+                parseSlotStatsRoot(current.dashboardCustomTiles)
+                    .also { it.remove(displaced) }.toString()
+            else current.dashboardCustomTiles
+
+            settingsRepository.update(
+                current.copy(
+                    dashboardMetricOrder = items.joinToString(","),
+                    dashboardCompositeMetrics = newComposites,
+                    dashboardCustomTiles = newCustomTiles
+                )
+            )
+        }
+    }
+
+    /**
+     * Catalog-model copy for actions — symmetric counterpart to
+     * [setDashboardMetricAtIndex]. Deletes the displaced action group's
+     * definition if any.
+     */
+    fun setDashboardActionAtIndex(key: String, slotIndex: Int) {
+        viewModelScope.launch {
+            val current = settingsRepository.get()
+            val items = sanitize(
+                current.dashboardActionOrder,
+                knownDashboardActions,
+                listActionGroups(current).keys
+            ).toMutableList()
+            if (slotIndex !in 0 until ACTIVE_DASHBOARD_TILE_COUNT) return@launch
+            if (slotIndex !in items.indices) return@launch
+            val displaced = items[slotIndex]
+            if (displaced == key) return@launch
+
+            items[slotIndex] = key
+            if (isActionGroupKey(displaced)) {
+                items.removeAll { it == displaced }
+            }
+
+            val newGroups = if (isActionGroupKey(displaced))
+                parseSlotStatsRoot(current.dashboardActionGroups)
+                    .also { it.remove(displaced) }.toString()
+            else current.dashboardActionGroups
+
+            settingsRepository.update(
+                current.copy(
+                    dashboardActionOrder = items.joinToString(","),
+                    dashboardActionGroups = newGroups
+                )
+            )
+        }
+    }
+
+    /**
+     * Drops [key] into position [toIndex] of the metric order, swapping with
+     * whatever previously occupied that slot. Works for both grid-to-grid
+     * reorder and pool-to-grid promotion: anything pushed past the active-slot
+     * count (cols * 3) naturally lands in the pool again.
+     */
+    fun moveDashboardMetricToIndex(key: String, toIndex: Int) {
+        viewModelScope.launch {
+            val current = settingsRepository.get()
+            // Pass composite + custom-tile IDs as `dynamic` so sanitize keeps
+            // them in the order list — otherwise a stack or custom-link tile
+            // dragged between slots would silently vanish from the persisted
+            // layout.
+            val items = sanitize(
+                current.dashboardMetricOrder,
+                knownDashboardMetrics,
+                listCompositeMetrics(current).keys + listCustomTiles(current).keys
+            ).toMutableList()
+            val fromIndex = items.indexOf(key)
+            if (fromIndex < 0 || toIndex !in items.indices) return@launch
+            if (fromIndex == toIndex) return@launch
+            // Swap so the slot the user dragged onto receives the new metric and
+            // its previous occupant takes the dragged item's old position.
+            val a = items[fromIndex]
+            items[fromIndex] = items[toIndex]
+            items[toIndex] = a
+
+            // Composites and custom tiles are rider-personal artifacts that
+            // only make sense on the active grid. If a swap pushed one into
+            // the pool, delete it (definition + order entry) rather than
+            // leaving it cluttering Available metrics. Within the active
+            // grid the rider can still reorder them freely — only the trip
+            // into the pool is destructive.
+            val activeCount = ACTIVE_DASHBOARD_TILE_COUNT
+            val orphanedComposites = items.withIndex()
+                .filter { (idx, k) -> idx >= activeCount && isCompositeMetricKey(k) }
+                .map { it.value }
+            val orphanedCustomTiles = items.withIndex()
+                .filter { (idx, k) -> idx >= activeCount && isCustomTileKey(k) }
+                .map { it.value }
+            if (orphanedComposites.isEmpty() && orphanedCustomTiles.isEmpty()) {
+                settingsRepository.update(current.copy(dashboardMetricOrder = items.joinToString(",")))
+            } else {
+                val compositesRoot = parseSlotStatsRoot(current.dashboardCompositeMetrics)
+                orphanedComposites.forEach { compositesRoot.remove(it) }
+                val tilesRoot = parseSlotStatsRoot(current.dashboardCustomTiles)
+                orphanedCustomTiles.forEach { tilesRoot.remove(it) }
+                val toRemove = (orphanedComposites + orphanedCustomTiles).toSet()
+                val cleaned = items.filter { it !in toRemove }
+                settingsRepository.update(
+                    current.copy(
+                        dashboardMetricOrder = cleaned.joinToString(","),
+                        dashboardCompositeMetrics = compositesRoot.toString(),
+                        dashboardCustomTiles = tilesRoot.toString()
+                    )
+                )
+            }
+        }
+    }
+
+    fun moveDashboardActionToIndex(key: String, toIndex: Int) {
+        viewModelScope.launch {
+            val current = settingsRepository.get()
+            val items = sanitize(
+                current.dashboardActionOrder,
+                knownDashboardActions,
+                listActionGroups(current).keys
+            ).toMutableList()
+            val fromIndex = items.indexOf(key)
+            if (fromIndex < 0 || toIndex !in items.indices) return@launch
+            if (fromIndex == toIndex) return@launch
+            val a = items[fromIndex]
+            items[fromIndex] = items[toIndex]
+            items[toIndex] = a
+
+            // Symmetric to the metric grid: an action group only makes sense
+            // on the active grid. If a swap pushed one into the pool, delete
+            // its definition + order entry — no orphan groups in Available
+            // actions.
+            val activeCount = ACTIVE_DASHBOARD_TILE_COUNT
+            val orphanedGroups = items.withIndex()
+                .filter { (idx, k) -> idx >= activeCount && isActionGroupKey(k) }
+                .map { it.value }
+            if (orphanedGroups.isEmpty()) {
+                settingsRepository.update(current.copy(dashboardActionOrder = items.joinToString(",")))
+            } else {
+                val groupsRoot = parseSlotStatsRoot(current.dashboardActionGroups)
+                orphanedGroups.forEach { groupsRoot.remove(it) }
+                val cleaned = items.filter { it !in orphanedGroups }
+                settingsRepository.update(
+                    current.copy(
+                        dashboardActionOrder = cleaned.joinToString(","),
+                        dashboardActionGroups = groupsRoot.toString()
+                    )
+                )
+            }
+        }
+    }
+
+    /**
+     * Restore the metric slot at [slotIndex] to the metric the app ships
+     * there (`knownDashboardMetrics[slotIndex]`), regardless of what the
+     * rider currently has in that slot. If the natural occupant lives in
+     * a different position, swap so it returns home and the displaced
+     * tile takes its place. Any dynamic tile (composite / custom-tile)
+     * pushed past the active region by the swap is cleaned up the same
+     * way the swap-via-drag path handles it.
+     */
+    fun resetDashboardMetricAtIndex(slotIndex: Int) {
+        viewModelScope.launch {
+            val current = settingsRepository.get()
+            val items = sanitize(
+                current.dashboardMetricOrder,
+                knownDashboardMetrics,
+                listCompositeMetrics(current).keys + listCustomTiles(current).keys
+            ).toMutableList()
+            val naturalKey = knownDashboardMetrics.getOrNull(slotIndex) ?: return@launch
+            if (slotIndex !in items.indices) return@launch
+            val currentOccupant = items[slotIndex]
+
+            // Note: don't early-return when currentOccupant == naturalKey.
+            // The rider may have customized corner stats (AVG / MIN / etc.)
+            // on the natural occupant, and Reset still needs to wipe those
+            // so the slot looks like a fresh install.
+
+            val occupantIsDynamic = isCompositeMetricKey(currentOccupant) ||
+                isCustomTileKey(currentOccupant)
+            val needsReorder = currentOccupant != naturalKey
+
+            if (needsReorder && occupantIsDynamic) {
+                // Dynamic occupant (composite / custom tile) gets deleted —
+                // the rider's "restore this slot" intent doesn't preserve
+                // dynamic instances. Remove it from the order, then move
+                // the natural metric into slotIndex (closing any gap).
+                items.removeAt(slotIndex)
+                val naturalIdx = items.indexOf(naturalKey)
+                if (naturalIdx >= 0) items.removeAt(naturalIdx)
+                items.add(slotIndex.coerceAtMost(items.size), naturalKey)
+            } else if (needsReorder) {
+                // Static occupant — swap with the natural metric's current
+                // position so neither static metric is lost.
+                val naturalIdx = items.indexOf(naturalKey)
+                if (naturalIdx >= 0) {
+                    items[naturalIdx] = currentOccupant
+                    items[slotIndex] = naturalKey
+                } else {
+                    items[slotIndex] = naturalKey
+                    items.add(currentOccupant)
+                }
+            }
+
+            // Clean up: any dynamic tile sitting in the pool (past
+            // activeCount) is implicitly orphaned, plus the one we just
+            // deleted at slotIndex (if any). Drop them from the order and
+            // their JSON definition map.
+            val activeCount = ACTIVE_DASHBOARD_TILE_COUNT
+            val orphanedComposites = items.withIndex()
+                .filter { (idx, k) -> idx >= activeCount && isCompositeMetricKey(k) }
+                .map { it.value }
+                .toMutableSet()
+            val orphanedCustomTiles = items.withIndex()
+                .filter { (idx, k) -> idx >= activeCount && isCustomTileKey(k) }
+                .map { it.value }
+                .toMutableSet()
+            if (occupantIsDynamic) {
+                if (isCompositeMetricKey(currentOccupant)) orphanedComposites.add(currentOccupant)
+                if (isCustomTileKey(currentOccupant)) orphanedCustomTiles.add(currentOccupant)
+            }
+            val toRemove = (orphanedComposites + orphanedCustomTiles)
+            val cleaned = if (toRemove.isEmpty()) items else items.filter { it !in toRemove }
+            val newComposites = if (orphanedComposites.isEmpty()) current.dashboardCompositeMetrics
+                else parseSlotStatsRoot(current.dashboardCompositeMetrics)
+                    .also { root -> orphanedComposites.forEach { root.remove(it) } }
+                    .toString()
+            val newCustomTiles = if (orphanedCustomTiles.isEmpty()) current.dashboardCustomTiles
+                else parseSlotStatsRoot(current.dashboardCustomTiles)
+                    .also { root -> orphanedCustomTiles.forEach { root.remove(it) } }
+                    .toString()
+
+            // Also wipe the natural key's per-slot stats so the restored
+            // metric shows up with its shipped appearance (current value
+            // in the center, no AVG / MIN / sparkline carry-over from the
+            // slot it used to live in). Without this, BATTERY brings its
+            // previously-configured corner stats along when it returns
+            // home, which makes the "Default" button feel half-applied.
+            val statsRoot = parseSlotStatsRoot(current.dashboardMetricStats)
+            statsRoot.remove(naturalKey)
+
+            settingsRepository.update(
+                current.copy(
+                    dashboardMetricOrder = cleaned.joinToString(","),
+                    dashboardCompositeMetrics = newComposites,
+                    dashboardCustomTiles = newCustomTiles,
+                    dashboardMetricStats = statsRoot.toString()
+                )
+            )
+        }
+    }
+
+    /**
+     * Restore the action slot at [slotIndex] to `knownDashboardActions[slotIndex]`
+     * — symmetric counterpart to [resetDashboardMetricAtIndex]. Cleans up any
+     * action-group definitions pushed past the active region.
+     */
+    fun resetDashboardActionAtIndex(slotIndex: Int) {
+        viewModelScope.launch {
+            val current = settingsRepository.get()
+            val items = sanitize(
+                current.dashboardActionOrder,
+                knownDashboardActions,
+                listActionGroups(current).keys
+            ).toMutableList()
+            val naturalKey = knownDashboardActions.getOrNull(slotIndex) ?: return@launch
+            if (slotIndex !in items.indices) return@launch
+            val currentOccupant = items[slotIndex]
+
+            val occupantIsGroup = isActionGroupKey(currentOccupant)
+            val needsReorder = currentOccupant != naturalKey
+
+            if (needsReorder && occupantIsGroup) {
+                items.removeAt(slotIndex)
+                val naturalIdx = items.indexOf(naturalKey)
+                if (naturalIdx >= 0) items.removeAt(naturalIdx)
+                items.add(slotIndex.coerceAtMost(items.size), naturalKey)
+            } else if (needsReorder) {
+                val naturalIdx = items.indexOf(naturalKey)
+                if (naturalIdx >= 0) {
+                    items[naturalIdx] = currentOccupant
+                    items[slotIndex] = naturalKey
+                } else {
+                    items[slotIndex] = naturalKey
+                    items.add(currentOccupant)
+                }
+            }
+
+            val activeCount = ACTIVE_DASHBOARD_TILE_COUNT
+            val orphanedGroups = items.withIndex()
+                .filter { (idx, k) -> idx >= activeCount && isActionGroupKey(k) }
+                .map { it.value }
+                .toMutableSet()
+            if (occupantIsGroup) orphanedGroups.add(currentOccupant)
+
+            val cleaned = if (orphanedGroups.isEmpty()) items else items.filter { it !in orphanedGroups }
+            val newGroups = if (orphanedGroups.isEmpty()) current.dashboardActionGroups
+                else parseSlotStatsRoot(current.dashboardActionGroups)
+                    .also { root -> orphanedGroups.forEach { root.remove(it) } }
+                    .toString()
+
+            settingsRepository.update(
+                current.copy(
+                    dashboardActionOrder = cleaned.joinToString(","),
+                    dashboardActionGroups = newGroups
+                )
+            )
+        }
+    }
+
+    // ---- Per-slot stat configuration ----
+    //
+    // Each metric in the active dashboard grid can put a different reading in
+    // its center and four corners: NONE, CURRENT, MIN, MAX or AVG over the
+    // configured rolling stats window. Stored as one JSON blob in AppSettings
+    // so adding a new corner or stat doesn't require a schema change.
+
+    fun dashboardMetricSlotStats(s: AppSettings, key: String): MetricSlotStats =
+        parseSlotStats(s.dashboardMetricStats, key)
+
+    fun updateDashboardMetricSlotStat(key: String, corner: SlotCorner, stat: DashboardStat) {
+        viewModelScope.launch {
+            val current = settingsRepository.get()
+            val root = parseSlotStatsRoot(current.dashboardMetricStats)
+            val node = root.optJSONObject(key) ?: org.json.JSONObject()
+            node.put(corner.jsonKey, stat.name)
+            root.put(key, node)
+            settingsRepository.update(current.copy(dashboardMetricStats = root.toString()))
+        }
+    }
+
+    fun updateDashboardMetricSparkline(key: String, enabled: Boolean) {
+        viewModelScope.launch {
+            val current = settingsRepository.get()
+            val root = parseSlotStatsRoot(current.dashboardMetricStats)
+            val node = root.optJSONObject(key) ?: org.json.JSONObject()
+            node.put("spark", enabled)
+            root.put(key, node)
+            settingsRepository.update(current.copy(dashboardMetricStats = root.toString()))
+        }
+    }
+
+    fun resetDashboardMetricSlotStats(key: String) {
+        viewModelScope.launch {
+            val current = settingsRepository.get()
+            val root = parseSlotStatsRoot(current.dashboardMetricStats)
+            root.remove(key)
+            settingsRepository.update(current.copy(dashboardMetricStats = root.toString()))
+        }
+    }
+
+    private fun parseSlotStatsRoot(s: String): org.json.JSONObject =
+        try { org.json.JSONObject(s.ifBlank { "{}" }) } catch (_: Exception) { org.json.JSONObject() }
+
+    private fun parseSlotStats(s: String, key: String): MetricSlotStats {
+        val root = parseSlotStatsRoot(s)
+        val n = root.optJSONObject(key) ?: return MetricSlotStats()
+        fun stat(k: String, default: DashboardStat) =
+            runCatching { DashboardStat.valueOf(n.optString(k, default.name)) }.getOrDefault(default)
+        return MetricSlotStats(
+            left = stat("l", DashboardStat.NONE),
+            center = stat("c", DashboardStat.CURRENT),
+            right = stat("r", DashboardStat.NONE),
+            sparkline = n.optBoolean("spark", true)
+        )
+    }
+
+    fun updateDashboardMetricsColumns(n: Int) = update { copy(dashboardMetricsColumns = n.coerceIn(2, 4)) }
+    fun updateDashboardActionsColumns(n: Int) = update { copy(dashboardActionsColumns = n.coerceIn(2, 4)) }
+    fun updateDashboardRollingWindowSeconds(seconds: Int) = update {
+        // Snap to the nearest preset so the dropdown's choices stay
+        // round-trippable even if a stray value sneaks in via JSON migration.
+        val snapped = ROLLING_WINDOW_PRESETS_SECONDS.minByOrNull { kotlin.math.abs(it - seconds) }
+            ?: ROLLING_WINDOW_DEFAULT_SECONDS
+        copy(dashboardRollingWindowSeconds = snapped)
+    }
+
+    fun moveDashboardMetric(fromIndex: Int, toIndex: Int) {
+        viewModelScope.launch {
+            val current = settingsRepository.get()
+            val items = sanitize(current.dashboardMetricOrder, knownDashboardMetrics).toMutableList()
+            if (fromIndex in items.indices && toIndex in items.indices) {
+                val item = items.removeAt(fromIndex)
+                items.add(toIndex, item)
+                settingsRepository.update(current.copy(dashboardMetricOrder = items.joinToString(",")))
+            }
+        }
+    }
+
+    fun moveDashboardAction(fromIndex: Int, toIndex: Int) {
+        viewModelScope.launch {
+            val current = settingsRepository.get()
+            val items = sanitize(current.dashboardActionOrder, knownDashboardActions).toMutableList()
+            if (fromIndex in items.indices && toIndex in items.indices) {
+                val item = items.removeAt(fromIndex)
+                items.add(toIndex, item)
+                settingsRepository.update(current.copy(dashboardActionOrder = items.joinToString(",")))
+            }
+        }
+    }
+
+    fun resetDashboardMetrics() = update {
+        copy(
+            dashboardMetricsColumns = 2,
+            dashboardMetricOrder = knownDashboardMetrics.joinToString(","),
+            dashboardRollingWindowSeconds = ROLLING_WINDOW_DEFAULT_SECONDS,
+            // Wipe composite + custom-tile definitions too — the rider's
+            // reset action is a "back to defaults" signal, which includes
+            // any custom stacks and personal-link tiles they had.
+            dashboardCompositeMetrics = "{}",
+            dashboardCustomTiles = "{}"
+        )
+    }
+
+    fun resetDashboardActions() = update {
+        copy(
+            dashboardActionsColumns = 3,
+            dashboardActionOrder = knownDashboardActions.joinToString(","),
+            dashboardActionGroups = "{}"
+        )
+    }
+
     fun syncFolderDisplayName(): String? {
         val s = settings.value ?: return null
         return syncManager.getSyncFolderDisplayName(s)
     }
+}
+
+/**
+ * Allowed rolling-window durations (seconds). Stored as a list so the dropdown
+ * UI and the snap-to-nearest validation share a single source of truth.
+ * Range covers a quick burst (30 s) up to a full commute hour.
+ */
+val ROLLING_WINDOW_PRESETS_SECONDS: List<Int> = listOf(
+    30, 60, 120, 180, 300, 600, 900, 1800, 3600
+)
+
+const val ROLLING_WINDOW_DEFAULT_SECONDS: Int = 300
+
+/**
+ * Layouts a composite metric tile can take. The cell count drives how many
+ * sub-metrics the rider picks in the edit sheet; the orientation drives how
+ * those values stack inside a single grid tile.
+ */
+enum class CompositeLayout(val cellCount: Int) {
+    /** Two cells stacked top/bottom — best for long values with units. */
+    ROW2(2),
+    /** Two cells side-by-side. */
+    COL2(2),
+    /** Three cells side-by-side. */
+    COL3(3)
+}
+
+/**
+ * Definition of a single composite metric instance. Stored in
+ * [AppSettings.dashboardCompositeMetrics] as `{ id: { layout, cells } }`.
+ * Sub-metric stats (min/max/avg) are intentionally NOT supported here — a
+ * composite always shows current values for each sub-metric.
+ */
+data class MetricComposite(
+    val layout: CompositeLayout = CompositeLayout.ROW2,
+    val cells: List<String> = listOf("SPEED", "BATTERY"),
+    /**
+     * Per-cell stat selector — what each cell displays. Parallel to
+     * [cells]. Defaults to [DashboardStat.CURRENT] (live value) so
+     * existing composites and freshly-spawned ones look the same as
+     * before. The rider can change it per cell in the composite edit
+     * sheet (Now / Min / Max / Avg / Sustained peak / Median / P75 /
+     * P95 / P99).
+     */
+    val cellStats: List<DashboardStat> = listOf(DashboardStat.CURRENT, DashboardStat.CURRENT, DashboardStat.CURRENT)
+)
+
+/**
+ * Tap behaviour for a custom tile. NONE renders as a display-only label;
+ * OPEN_URL launches the rider's URL in the default browser; SHOW_QR opens
+ * a QR-code popup so other riders can scan and visit the same URL (the
+ * Instagram-share use case).
+ */
+enum class CustomTileAction { NONE, OPEN_URL, SHOW_QR }
+
+/**
+ * Rider-defined dashboard tile: a chosen icon + text label, optionally
+ * paired with a tap action (open URL in browser, or show QR code popup).
+ * Lets the rider drop a contact card / social handle / club page onto the
+ * dashboard alongside their telemetry. Stored in
+ * [AppSettings.dashboardCustomTiles] keyed by `C:<uuid>`.
+ */
+data class CustomTile(
+    val text: String = "",
+    val icon: String = CUSTOM_TILE_DEFAULT_ICON,
+    val action: CustomTileAction = CustomTileAction.NONE,
+    val url: String = ""
+)
+
+/** Default icon for newly-spawned custom tiles. LINK reads as "tap-target"
+ *  even before the rider configures the action — most riders dragging the
+ *  template in are setting up a URL or QR, not just text. */
+const val CUSTOM_TILE_DEFAULT_ICON = "LINK"
+
+/**
+ * Definition of a single action group instance. Stored in
+ * [AppSettings.dashboardActionGroups] as `{ id: { name, icon, actions } }`.
+ * Up to 4 sub-actions; the rider can intentionally duplicate an action
+ * (e.g. two `RECORD_TOGGLE` entries if they want it twice in the popover).
+ * [icon] is a stable key from a curated set rendered by `groupIconFor` —
+ * not a raw image vector, so the storage stays JSON-stable across icon-set
+ * upgrades.
+ */
+data class ActionGroup(
+    val name: String = "",
+    val icon: String = GROUP_DEFAULT_ICON,
+    val actions: List<String> = emptyList()
+)
+
+/** Default icon key for new action groups. Matches the "+ GROUP" template
+ *  pill so the rider immediately recognises the freshly-spawned tile. */
+const val GROUP_DEFAULT_ICON = "FOLDER"
+
+/** Curated icon keys the rider can pick from in the group edit sheet and
+ *  the custom-tile edit sheet. The list lives here (not in the screen) so
+ *  the icon picker and the tile renderer share a single source of truth —
+ *  adding a new entry shows up everywhere automatically. */
+val GROUP_ICON_CHOICES: List<String> = listOf(
+    "FOLDER", "STAR", "BOLT", "FAVORITE", "DASHBOARD",
+    "EXTENSION", "TUNE", "WIDGETS", "APPS", "BUILD",
+    "HOME", "PERSON", "SETTINGS", "SHIELD", "MAP",
+    "PHOTO_CAMERA", "MUSIC_NOTE", "PHONE", "WIFI", "SEARCH",
+    "SAVE", "SEND", "SHARE", "EDIT", "REFRESH",
+    "DONE", "INFO", "WARNING", "NOTIFICATIONS", "LINK"
+)
+
+/** Number of active tiles in each dashboard grid (metrics + actions). The
+ *  rider always picks 6 active items regardless of column count (2×3 vs 3×2
+ *  is just a visual layout choice). VM logic uses this to decide whether a
+ *  given order-list index lands in the active grid or in the pool. */
+const val ACTIVE_DASHBOARD_TILE_COUNT = 6
+
+/** Prefix on order-list entries that identifies a composite metric instance. */
+const val COMPOSITE_METRIC_PREFIX = "M:"
+/** Prefix on order-list entries that identifies an action group instance. */
+const val ACTION_GROUP_PREFIX = "G:"
+/** Pool template key for the "+ Stack" composite-metric source. */
+const val COMPOSITE_TEMPLATE_KEY = "+M"
+/** Pool template key for the "+ Group" action-group source. */
+const val ACTION_GROUP_TEMPLATE_KEY = "+G"
+/**
+ * Prefix marking a composite cell value as rider-typed text rather than a
+ * metric key. The string after the prefix is the literal text the cell
+ * renders on the grid; blank content reads as "(empty)" faint placeholder.
+ * Lets the rider drop a label like "Pack 1" into a stack tile next to the
+ * actual battery reading.
+ *
+ * Examples:
+ *  - "TEXT:" → empty text cell, shows "(empty)" placeholder
+ *  - "TEXT:Right pack" → cell renders "Right pack"
+ */
+const val COMPOSITE_TEXT_PREFIX = "TEXT:"
+
+/** Pseudo-metric for an unbound composite cell. Stored as the TEXT prefix
+ *  with no content, which renders as the "(empty)" placeholder. Treated as
+ *  equivalent to the legacy "EMPTY" sentinel from earlier in-development
+ *  builds. */
+const val COMPOSITE_CELL_EMPTY = COMPOSITE_TEXT_PREFIX
+
+/** Prefix on order-list entries that identifies a custom tile (rider-typed
+ *  text + icon + optional tap action like launching a URL or showing a QR
+ *  code). Lives in [AppSettings.dashboardCustomTiles] keyed by `C:<uuid>`. */
+const val CUSTOM_TILE_PREFIX = "C:"
+/** Pool template key for the "+ Custom" custom-tile source. */
+const val CUSTOM_TILE_TEMPLATE_KEY = "+C"
+
+fun isCompositeMetricKey(key: String): Boolean = key.startsWith(COMPOSITE_METRIC_PREFIX)
+fun isActionGroupKey(key: String): Boolean = key.startsWith(ACTION_GROUP_PREFIX)
+fun isCustomTileKey(key: String): Boolean = key.startsWith(CUSTOM_TILE_PREFIX)
+fun isTextCell(key: String): Boolean = key.startsWith(COMPOSITE_TEXT_PREFIX) || key == "EMPTY"
+fun textCellContent(key: String): String = when {
+    key == "EMPTY" -> ""
+    key.startsWith(COMPOSITE_TEXT_PREFIX) -> key.removePrefix(COMPOSITE_TEXT_PREFIX)
+    else -> ""
+}
+fun wrapAsTextCell(content: String): String = COMPOSITE_TEXT_PREFIX + content
+
+// Stats are listed in dropdown order. SUSTAINED_PEAK sits next to MAX because
+// it's a softer "Peak ignoring spikes shorter than 2s" companion — the same
+// reading Inmotion shows as "Sustained peak". Percentiles ascend so the
+// picker reads: None / Now / Min / Max / Sustained peak / Avg / Median (P50)
+// / P75 / P95 / P99.
+enum class DashboardStat {
+    NONE, CURRENT, MIN, MAX, SUSTAINED_PEAK, AVG, MEDIAN, P75, P95, P99
+}
+
+enum class SlotCorner(val jsonKey: String) {
+    LEFT("l"), CENTER("c"), RIGHT("r")
+}
+
+data class MetricSlotStats(
+    val left: DashboardStat = DashboardStat.NONE,
+    val center: DashboardStat = DashboardStat.CURRENT,
+    val right: DashboardStat = DashboardStat.NONE,
+    val sparkline: Boolean = true
+) {
+    fun stat(corner: SlotCorner): DashboardStat = when (corner) {
+        SlotCorner.LEFT -> left
+        SlotCorner.CENTER -> center
+        SlotCorner.RIGHT -> right
+    }
+
+    /** True only when the rider hasn't customized any side reading. */
+    val isDefault: Boolean
+        get() = left == DashboardStat.NONE &&
+            center == DashboardStat.CURRENT &&
+            right == DashboardStat.NONE
 }
 
 sealed interface CloudEvent {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,6 +102,173 @@
     <string name="tab_watch">Watch</string>
     <string name="tab_cloud">Backup settings &amp; trips</string>
 
+    <!-- Dashboard layout (customizable home screen) -->
+    <string name="tab_dashboard">Dashboard layout</string>
+    <string name="dashboard_section_gauge">Speed gauge</string>
+    <string name="dashboard_section_gauge_caption">The gauge always shows speed and stays at the top of the dashboard.</string>
+    <string name="dashboard_section_metrics">Metrics</string>
+    <string name="dashboard_section_actions">Action buttons</string>
+    <string name="dashboard_columns">Columns</string>
+    <string name="dashboard_grid_hint">Long-press to drag. Tap to edit.</string>
+    <string name="dashboard_pool_metrics">Available metrics</string>
+    <string name="dashboard_pool_actions">Available actions</string>
+    <string name="dashboard_pool_hint">Drag onto the grid to use.</string>
+    <string name="dashboard_pool_tap_toast">Long-press and drag onto a slot above to use.</string>
+    <string name="dashboard_rolling_window">Rolling stats window</string>
+    <string name="dashboard_stats_length">Stats length</string>
+    <string name="dashboard_view">View</string>
+    <string name="dashboard_view_default">Default</string>
+    <string name="dashboard_view_wide">Wide</string>
+    <string name="dashboard_composite_template_label">MULTI</string>
+    <string name="dashboard_group_template_label">GROUP</string>
+    <string name="dashboard_composite_layout_label">Layout</string>
+    <string name="dashboard_composite_layout_row2">2 rows</string>
+    <string name="dashboard_composite_layout_col2">2 cols</string>
+    <string name="dashboard_composite_layout_col3">3 cols</string>
+    <string name="dashboard_composite_cell_label">Cell %1$d</string>
+    <string name="dashboard_composite_empty_label">(empty)</string>
+    <string name="dashboard_group_default_name">My actions</string>
+    <string name="dashboard_group_name_label">Group name</string>
+    <string name="dashboard_group_icon_label">Icon</string>
+    <string name="dashboard_group_action_slot">Action %1$d</string>
+    <string name="dashboard_group_action_none">(none)</string>
+    <string name="dashboard_custom_tile_template_label">TEXT</string>
+    <string name="dashboard_custom_tile_text_label">Text</string>
+    <string name="dashboard_custom_tile_text_placeholder">e.g. My Instagram</string>
+    <string name="dashboard_custom_tile_action_label">Tap action</string>
+    <string name="dashboard_custom_tile_action_none">Text</string>
+    <string name="dashboard_custom_tile_action_url">Open URL</string>
+    <string name="dashboard_custom_tile_action_qr">Show QR</string>
+    <string name="dashboard_custom_tile_url_label">URL</string>
+    <string name="dashboard_rolling_window_30s">30 sec</string>
+    <string name="dashboard_rolling_window_1m">1 min</string>
+    <string name="dashboard_rolling_window_2m">2 min</string>
+    <string name="dashboard_rolling_window_3m">3 min</string>
+    <string name="dashboard_rolling_window_5m">5 min</string>
+    <string name="dashboard_rolling_window_10m">10 min</string>
+    <string name="dashboard_rolling_window_15m">15 min</string>
+    <string name="dashboard_rolling_window_30m">30 min</string>
+    <string name="dashboard_rolling_window_1h">1 hour</string>
+    <string name="dashboard_wide_hint">Tablets and foldables get +1 column.</string>
+    <string name="dashboard_wide_preview">Showing the %1$d-column tablet layout for the current %2$d-column setting.</string>
+    <string name="dashboard_slot_reset">Reset this metric to default position</string>
+    <string name="dashboard_slot_reset_action">Reset this action to default position</string>
+    <string name="dashboard_reset_short">Reset</string>
+    <string name="dashboard_restore_slot">Restore slot</string>
+    <string name="metric_detail_reset">Reset</string>
+    <string name="metric_detail_reset_all">Reset all</string>
+    <string name="metric_detail_reset_all_confirm_title">Reset all history?</string>
+    <string name="metric_detail_reset_all_confirm_body">Clears the rolling history buffer for every metric. Settings and trip records are not affected.</string>
+    <string name="metric_detail_show_label">Value</string>
+    <string name="metric_detail_long_press_hint">Long-press for Reset all</string>
+    <string name="dashboard_close">Close</string>
+    <string name="dashboard_slot_corners_label">Side readings</string>
+    <string name="dashboard_corner_left">Left</string>
+    <string name="dashboard_corner_center">Center</string>
+    <string name="dashboard_corner_right">Right</string>
+    <string name="dashboard_slot_sparkline">Live trend background</string>
+    <string name="dashboard_slot_sparkline_chip">Stats</string>
+    <string name="dashboard_slot_reset_hint">Removes the side readings and moves this metric back to its starting position in the grid.</string>
+    <string name="dashboard_slot_reset_hint_action">Moves this action back to its starting position in the grid.</string>
+    <string name="dashboard_stat_none">—</string>
+    <string name="dashboard_stat_current">Now</string>
+    <string name="dashboard_stat_min">Min</string>
+    <string name="dashboard_stat_max">Max / Peak</string>
+    <string name="dashboard_stat_sustained_peak">Sustained peak</string>
+    <string name="dashboard_stat_sustained_peak_short">S.Peak</string>
+    <string name="dashboard_stat_avg">Avg</string>
+    <string name="dashboard_stat_median">Median (P50)</string>
+    <string name="dashboard_stat_p75">75th percentile</string>
+    <string name="dashboard_stat_p95">95th percentile</string>
+    <string name="dashboard_stat_p99">99th percentile</string>
+    <!-- Short variants used inside the dropdown trailing-icon field when an
+         option is selected; the menu list still shows the verbose name above. -->
+    <string name="dashboard_stat_median_short">P50</string>
+    <string name="dashboard_stat_p75_short">P75</string>
+    <string name="dashboard_stat_p95_short">P95</string>
+    <string name="dashboard_stat_p99_short">P99</string>
+
+    <!-- Metric labels for the dashboard layout chips -->
+    <string name="metric_chip_battery">Battery</string>
+    <string name="metric_chip_temperature">Temperature</string>
+    <string name="metric_chip_voltage">Voltage</string>
+    <string name="metric_chip_current">Amps</string>
+    <string name="metric_chip_load">Load (PWM)</string>
+    <string name="metric_chip_trip">Trip</string>
+    <string name="metric_chip_speed">Speed</string>
+    <string name="metric_chip_power">Power</string>
+    <string name="metric_chip_odometer">Odometer</string>
+    <string name="metric_chip_motor_power">Motor power</string>
+    <string name="metric_chip_battery_power">Battery power</string>
+    <string name="metric_chip_battery_1">Pack 1</string>
+    <string name="metric_chip_battery_2">Pack 2</string>
+    <string name="metric_chip_pitch">Pitch</string>
+    <string name="metric_chip_roll">Roll</string>
+    <string name="metric_chip_g_force">G-force</string>
+    <string name="metric_chip_lateral_g">Lateral g</string>
+    <string name="metric_chip_forward_g">Forward g</string>
+    <string name="metric_chip_torque">Torque</string>
+    <string name="metric_chip_dyn_speed_limit">Dyn. speed lim.</string>
+    <string name="metric_chip_dyn_current_limit">Dyn. current lim.</string>
+    <string name="metric_chip_motor_temp">Motor temp</string>
+    <string name="metric_chip_controller_temp">Controller</string>
+    <string name="metric_chip_battery_temp">Battery temp</string>
+    <string name="metric_chip_headroom">Headroom</string>
+    <string name="metric_chip_trip_time">Trip time</string>
+    <string name="metric_chip_trip_max_speed">Trip max</string>
+    <string name="metric_chip_avg_trip_speed">Avg speed</string>
+    <string name="metric_chip_wh_consumed">Energy</string>
+    <string name="metric_chip_range_estimate">Range</string>
+    <string name="metric_chip_wh_per_km">Wh / km</string>
+    <string name="metric_chip_phone_battery">Phone bat.</string>
+    <string name="metric_chip_gps_altitude">Altitude</string>
+    <string name="metric_chip_gps_speed">GPS speed</string>
+    <string name="metric_chip_gps_heading">Heading</string>
+    <string name="metric_chip_gps_accuracy">GPS acc.</string>
+    <string name="metric_chip_slope">Slope</string>
+    <string name="metric_chip_ascent">Ascent</string>
+    <string name="metric_chip_descent">Descent</string>
+    <string name="metric_chip_motor_rpm">RPM</string>
+    <string name="metric_chip_regen_wh">Regen</string>
+    <string name="metric_chip_bt_rssi">BT signal</string>
+
+    <!-- Descriptions shown in the slot-sheet info box for metrics whose
+         meaning isn't obvious from the name alone. Strings end with a
+         period so they read like complete sentences. -->
+    <string name="metric_desc_headroom">Speed margin remaining before tilt-back kicks in. Big number = more safety buffer.</string>
+    <string name="metric_desc_trip_max_speed">Peak speed during the current trip (resets on a new trip).</string>
+    <string name="metric_desc_avg_trip_speed">Trip distance divided by riding time so far.</string>
+    <string name="metric_desc_wh_consumed">Total watt-hours drawn from the battery this trip.</string>
+    <string name="metric_desc_range_estimate">Distance remaining at the current consumption rate.</string>
+    <string name="metric_desc_wh_per_km">Energy used per kilometre — lower is more efficient.</string>
+    <string name="metric_desc_slope">Road grade calculated from the wheel\'s pitch — positive is uphill.</string>
+    <string name="metric_desc_regen_wh">Total watt-hours fed back to the battery while braking this trip.</string>
+    <string name="metric_desc_bt_rssi">Bluetooth signal strength to the wheel — closer to 0 dBm is stronger.</string>
+    <string name="metric_desc_gps_accuracy">GPS positioning error radius — lower is more accurate.</string>
+
+    <!-- Action labels for the dashboard layout chips -->
+    <string name="action_chip_horn">Horn</string>
+    <string name="action_chip_light">Light</string>
+    <string name="action_chip_voice">Voice</string>
+    <string name="action_chip_safety">Legal mode</string>
+    <string name="action_chip_lock">Lock wheel</string>
+    <string name="action_chip_record">Recorder</string>
+    <string name="action_chip_safety_on">Legal ON</string>
+    <string name="action_chip_safety_off">Legal OFF</string>
+    <string name="action_chip_record_start">Rec start</string>
+    <string name="action_chip_record_stop">Rec stop</string>
+    <string name="action_chip_media_play">Play / pause</string>
+    <string name="action_chip_media_next">Next track</string>
+    <string name="action_chip_media_prev">Prev track</string>
+    <string name="action_chip_open_navigation">Show map</string>
+    <string name="action_chip_open_studio">Overlay studio</string>
+    <string name="action_chip_open_about">About</string>
+    <string name="action_chip_open_service">Service mode</string>
+    <string name="action_chip_open_trips">Trips</string>
+    <string name="action_chip_mute_alarms">Mute alarms</string>
+    <string name="action_chip_reset_trip">Reset trip</string>
+    <string name="action_chip_toggle_units">Toggle units</string>
+
     <!-- Wear OS companion settings -->
     <string name="section_watch_general">General</string>
     <string name="section_watch_display">Display</string>
@@ -501,7 +668,7 @@
     <string name="scan_show_all_subtitle">Turn on if your wheel does not appear</string>
 
     <!-- Metric detail -->
-    <string name="metric_detail_title">%1$s</string>
+    <string name="metric_detail_title">History</string>
     <string name="metric_no_data">No data</string>
     <string name="metric_min">MIN</string>
     <string name="metric_avg">AVG</string>

--- a/docs/CUSTOMIZABLE_DASHBOARD_PLAN.md
+++ b/docs/CUSTOMIZABLE_DASHBOARD_PLAN.md
@@ -1,0 +1,496 @@
+# Customizable Dashboard — Design Plan
+
+Status: **DRAFT — for review, no code yet**
+Branch: `customizable-dashboard`
+
+## Goal
+
+Let users tailor the home Dashboard without surfacing a fragmented settings page.
+Two things become user-editable:
+
+- **Metrics grid** (currently fixed 2×3: Battery, Temp, Voltage, Current/Watts, Load, Trip)
+- **Actions grid** (currently fixed 3×2: Horn, Light, Voice, Safety, Lock, Recorder)
+
+Both editors must feel "compact, looks good, not many pages". The interaction
+model below is built around **one settings screen + one bottom-sheet per slot**
+so configuration never spawns a tree of sub-pages.
+
+---
+
+## 1. Naming & placement
+
+### Recommended name: **"Dashboard layout"**
+
+Reasoning:
+- `Personalization` and `App customization` are vague (would they also cover
+  theme, accent, units? those already live in `Display`).
+- `Dashboard layout` is the smallest accurate description and parallels the
+  industry-standard term ("home screen layout").
+- Sister tabs are single nouns: General, Display, Speed, Voice, Cloud, Alarms,
+  Automations, Integration, Navigator. `Dashboard` fits that cadence.
+
+### Placement: **new top-level tab between `General` and `Display`** in `SettingsScreen.kt`
+
+- Icon: `Icons.Filled.Dashboard` (or `DashboardCustomize`)
+- Tab key: `"dashboard"`
+- Tab index: insert at position 1, shift `display`→2, `speed`→3, etc.
+  - All callers using `onNavigateToSettings(N)` need re-indexing; check
+    `DashboardScreen.kt` long-press menus (lines 949, 974, 1004, 1028, 1052) and
+    Flic/Watch deeplinks.
+  - Or: drop numeric indices, navigate by tab **key** (small refactor; cleaner).
+
+Rejected alternative: putting this under `Display`. Display is about appearance
+chrome (theme, accent, gauge color band). Layout is structurally bigger and
+needs its own tab room.
+
+---
+
+## 2. The settings screen layout
+
+One scrollable screen. Three collapsible sections, all expanded by default the
+first time the screen is opened.
+
+```
+┌─────────────────────────────────────────────────────┐
+│ Dashboard layout                                    │
+├─────────────────────────────────────────────────────┤
+│ ▼ Speed gauge                                       │
+│   Tap-to-detail metric  [Speed ▾]                   │
+│   (gauge itself is always shown, always speed)      │
+├─────────────────────────────────────────────────────┤
+│ ▼ Metrics grid                                      │
+│   Columns:  ( 2 ) [ 3 ] [ 4 ]                       │
+│                                                     │
+│   Slot 1            Slot 2            Slot 3        │
+│   ┌────────┐        ┌────────┐        ┌────────┐    │
+│   │Battery │   ⠿    │  Temp  │   ⠿    │Voltage │    │
+│   │  78%   │        │  42°C  │        │ 84.2V  │    │
+│   └────────┘        └────────┘        └────────┘    │
+│   Slot 4            Slot 5            Slot 6        │
+│   ┌────────┐        ┌────────┐        ┌────────┐    │
+│   │Current │   ⠿    │  Load  │   ⠿    │ Trip   │    │
+│   │ 12.4A  │        │  31%   │        │ 14.2km │    │
+│   └────────┘        └────────┘        └────────┘    │
+│                                                     │
+│   Rolling window for min/max/avg:  [— ●─── +] 5 min │
+│                                                     │
+│   [ Reset to defaults ]                             │
+├─────────────────────────────────────────────────────┤
+│ ▼ Action buttons                                    │
+│   Columns:  [ 2 ] ( 3 ) [ 4 ]                       │
+│                                                     │
+│   ┌───────┐  ┌───────┐  ┌───────┐                   │
+│   │ Horn  │⠿ │ Light │⠿ │ Voice │                   │
+│   └───────┘  └───────┘  └───────┘                   │
+│   ┌───────┐  ┌───────┐  ┌───────┐                   │
+│   │Legal  │⠿ │ Lock  │⠿ │Record │                   │
+│   └───────┘  └───────┘  └───────┘                   │
+│                                                     │
+│   [ Reset to defaults ]                             │
+└─────────────────────────────────────────────────────┘
+```
+
+Notes:
+- ⠿ = drag handle. The slot itself is **tap-to-edit**, the handle is
+  **long-press-to-drag** — same `sh.calvin.reorderable` library already used by
+  Alarm rules.
+- Columns selector is a 3-chip toggle (segmented control). Live previews update
+  immediately as the user toggles.
+- The mini cards inside the settings screen mirror the real dashboard widget
+  rendering (same `StatCard` composable) — keeps the editor compact because
+  there's no parallel "settings card" art to maintain.
+- Showing live values (78%, 42°C…) keeps the editor "alive" and removes the
+  need for a separate preview button. If disconnected, show last-known or a
+  static "—".
+
+---
+
+## 3. Per-widget editor (bottom sheet, not a new page)
+
+Tapping a metric slot opens a modal **bottom sheet** with the zoomed widget at
+top and the configuration controls below. Closing it commits changes — no
+explicit Save button.
+
+```
+┌─────────────────────────────────────────────────────┐
+│ Slot 4                                       [ × ]  │
+│                                                     │
+│   ┌─────────────────────────────────────────────┐   │
+│   │                                             │   │
+│   │   min  →     12.4 A      ← max              │   │
+│   │              (current)                      │   │
+│   │           ╱╲                                │   │
+│   │          ╱  ╲    ╱╲     avg                 │   │
+│   │   ─────╱────╲──╱──╲─────                    │   │
+│   │                                             │   │
+│   └─────────────────────────────────────────────┘   │
+│                                                     │
+│   Metric:                                           │
+│   [Battery] [Temp] [Volt] (Curr) [Load] [Trip]      │
+│   [Watts] [Speed] [PWM] [Alt] [Tilt] [Distance]     │
+│                                                     │
+│   Show:                                             │
+│      Center           Top-left      Top-right       │
+│      [Current ▾]      [Min ▾]       [Max ▾]         │
+│      Bottom-left      Bottom-right                  │
+│      [—   ▾]          [Avg ▾]                       │
+│                                                     │
+│   [x] Show trend sparkline                          │
+│   Long-press toggles: ( Amps ↔ Watts )              │
+└─────────────────────────────────────────────────────┘
+```
+
+Why slots instead of free-drag:
+- The user described drag-into-zones ("drag MAX to the right side"). True
+  drag-and-drop into pixel zones is fiddly on a phone and breaks A11y. **Five
+  fixed slots with dropdowns** gives the same result — every slot can hold
+  Current / Min / Max / Avg / Median / P95 / None / Trend — without the user
+  hunting for hit-targets. The zoomed preview at the top renders exactly what
+  each slot choice would look like, so the user still sees their layout.
+- If the slot is set to "None", the corner just disappears in the preview and
+  on the real widget.
+
+The **rolling window** lives at the section level (single slider, applies to
+all metrics) rather than per-widget, because:
+- Per-widget windows make min/max comparisons across cards meaningless.
+- Saves space in the bottom sheet.
+- If we later need per-widget windows, the section-level value becomes the
+  default and we add a "Custom window" override toggle.
+
+### Header copy in the bottom sheet
+> "Min, max and average use the last **5 minutes** of data. Change in
+> Dashboard layout → Metrics grid → Rolling window."
+
+(The "5 minutes" reflects the section-level slider.)
+
+---
+
+## 4. Action buttons editor
+
+The action grid uses the **same compact pattern**:
+
+- Tap a button slot → bottom sheet with:
+  - Action picker grouped by category
+  - Optional override: button label, accent color, long-press shortcut
+
+```
+┌─────────────────────────────────────────────────────┐
+│ Button slot 3                                [ × ]  │
+│                                                     │
+│   ┌──────────────┐                                  │
+│   │   📢 Horn    │   ← live preview                 │
+│   └──────────────┘                                  │
+│                                                     │
+│   Action:                                           │
+│   ▾ Wheel control                                   │
+│      ○ Horn               ○ Light                   │
+│      ○ Lock               ○ Legal mode toggle       │
+│      ○ Legal ON           ○ Legal OFF               │
+│   ▾ Recording                                       │
+│      ○ Record toggle      ○ Record start            │
+│      ○ Record stop                                  │
+│   ▾ Voice                                           │
+│      ○ Voice announce                               │
+│   ▾ Media                                           │
+│      ○ Play/Pause   ○ Next   ○ Previous             │
+│   ▾ None                                            │
+│      ● Hide this slot                               │
+│                                                     │
+│   Long-press shortcut: [ Open speed settings ▾ ]    │
+└─────────────────────────────────────────────────────┘
+```
+
+Action vocabulary is **the same enum already used by Flic and Wear OS**:
+`FlicAction` (AppSettings.kt:397-412) gives us 14 actions and the icons come
+from `WatchActionMeta.kt:26-37` — re-use both to avoid forking a third
+icon/label table.
+
+Add a tiny adapter that maps `FlicAction` → on-screen icon. We already have
+that mapping in `DashboardScreen.kt`'s current hard-coded buttons; extract it
+into `data/model/DashboardAction.kt` and let Dashboard, Flic settings, and
+Wear settings all read from it.
+
+---
+
+## 5. Data model (AppSettings additions)
+
+Add to `data/model/AppSettings.kt`:
+
+```kotlin
+data class DashboardLayout(
+    // Gauge is always shown and always speed (per Q1/Q2).
+    // Only the tap-to-detail target is user-pickable.
+    val gaugeTapMetric: MetricType = MetricType.SPEED,
+
+    val metricsColumns: Int = 2,                 // 2, 3, or 4 — for the current form factor.
+                                                  // The other form factor auto-bumps as today (Q5).
+    val metricsRollingWindowMinutes: Int = 5,    // 1, 2, 5, 10, 15, 30
+    val metricsSlots: List<MetricSlot> = defaultMetricsSlots(),
+
+    val actionsColumns: Int = 3,                 // 2, 3, or 4
+    val actionsSlots: List<ActionSlot> = defaultActionsSlots()
+)
+
+data class MetricSlot(
+    val metric: MetricType,                       // existing enum in MetricDetailScreen.kt
+    val center: Stat = Stat.CURRENT,
+    val topLeft: Stat = Stat.NONE,
+    val topRight: Stat = Stat.NONE,
+    val bottomLeft: Stat = Stat.NONE,
+    val bottomRight: Stat = Stat.NONE,
+    val showSparkline: Boolean = true
+)
+
+enum class Stat { NONE, CURRENT, MIN, MAX, AVG, MEDIAN, P95 }
+
+data class ActionSlot(
+    val action: FlicAction,                       // re-use existing enum
+    val longPressAction: FlicAction = FlicAction.NONE
+)
+```
+
+`AppSettings` already serializes as JSON via DataStore (per the explore report),
+so no migration code — old installs deserialize with the defaults above.
+
+---
+
+## 6. Aggregation (min/max/avg)
+
+`WheelRepository.fullHistory` already keeps a 5-minute, 1 Hz, per-metric
+`List<MetricSample>`. Add:
+
+```kotlin
+fun MetricHistory.aggregate(
+    nowMs: Long,
+    windowMinutes: Int
+): MetricAggregate
+```
+
+returning `min/max/avg/median/p95/last`. Compute on demand inside
+`DashboardViewModel` whenever `fullHistory` ticks — cheap enough (≤ 900 points
+× 6 metrics).
+
+**Edge case**: window > 5 min requires extending the repository's rolling
+buffer. Cap the UI slider at 5 min for v1, or extend the buffer to 30 min
+(900 → 1800 samples is negligible memory). I'd extend it — gives us room to
+expose 15/30-min options without another data-layer change.
+
+---
+
+## 7. Implementation phases
+
+| Phase | What | Risk |
+|---|---|---|
+| 1 | Extract `DashboardAction` (action+icon+label+handler) from inline `DashboardScreen.kt` so Dashboard, Flic, Wear, and new settings all read from one source | Low — pure refactor |
+| 2 | Add `DashboardLayout` to `AppSettings` with defaults; thread through `DashboardViewModel`; **render the dashboard from settings** (still showing the same six metrics and six actions by default) | Medium — touches main UI |
+| 3 | Add aggregation helper + extend rolling buffer to 30 min | Low |
+| 4 | New "Dashboard layout" settings tab — section A (metrics grid) | Medium |
+| 5 | Per-slot bottom sheet for metrics | Medium — new reusable widget |
+| 6 | Section B (actions grid) + per-slot bottom sheet for actions | Low (reuses phase 5 patterns) |
+| 7 | Polish: live preview animation, A11y labels, drag affordances, localization keys | — |
+
+Phase 2 is the keystone — once the dashboard reads from `DashboardLayout`
+instead of hard-coded composables, every later phase only changes settings UI,
+not runtime UI. So we ship phase 1+2 as a no-op refactor first, verify nothing
+regressed, then build the editor on top.
+
+---
+
+## 8. Locked decisions
+
+| # | Decision |
+|---|---|
+| 1 | **Dial stays locked to Speed.** Only the tap-to-detail metric is configurable. |
+| 2 | **Gauge always shown** — no hide toggle. |
+| 3 | **Per-section reset** buttons (one inside metrics grid, one inside actions grid). |
+| 4 | **Watch stays independently configured** under the Watch tab; phone Dashboard layout does not push to the watch. |
+| 5 | User configures for the **current form factor**; the other auto-bumps as today (foldables / tablets keep the existing +1-column behavior). |
+| 6 | Trip's Min/Max/Avg/Median/P95 in the per-slot editor are **visible but disabled** with a small "no history" caption — keeps the UI consistent across metrics. |
+
+---
+
+## 9. Build gate (standing requirement)
+
+Every phase ends green or it doesn't land:
+
+- `./gradlew assembleDebug` succeeds on Windows + Linux.
+- App installs and launches on the emulator (AVD pinned to a recent Pixel /
+  API level we already use in CI) without crashing on the dashboard.
+- The dashboard renders the same set of metrics and actions as before for a
+  fresh install (default `DashboardLayout` matches today's hard-coded layout
+  byte-for-byte visually).
+- After phase 4+, a brief smoke test on the emulator: open Settings → Dashboard
+  layout, drag one metric, change column count, open a slot editor, change a
+  corner stat → back to dashboard, confirm the change persisted across a
+  process restart.
+
+I'll run the build + emulator smoke test at the end of each phase and only
+move to the next when it's clean. If a phase introduces a hot crash on the
+dashboard, it gets reverted, not patched forward.
+
+---
+
+## 10. Expanded metric inventory
+
+Phase 4+ exposes these as choices in the per-slot "Metric:" picker. Items
+marked **(history)** already feed the rolling buffer in `WheelRepository`, so
+their Min/Max/Avg work for free. Items marked **(current only)** would either
+ship without those stats (corners gray out, same as Trip) or get a new history
+series added to `FullMetricHistory` — I'd ship current-only first and add
+history opportunistically in later phases.
+
+**Already buffered (Min/Max/Avg work out of the box):**
+1. Battery (%)
+2. Temperature — max sensor (°C/°F)
+3. Voltage (V)
+4. Current (A) — long-press toggles to Watts as today
+5. Load / PWM (%)
+6. Speed (km/h or mph) — new for the grid; previously dial-only
+
+**Current-only (no history yet — corners gray for Min/Max/Avg until we extend the buffer):**
+7. Trip distance (km/mi)
+8. Total distance / odometer (km/mi)
+9. Power — battery × current in Watts (V·A; already exists as the Current long-press swap)
+10. Motor power (W) — `wheelData.motorPower`
+11. Battery power (W) — `wheelData.batteryPower`
+12. Battery 1 (%) — split-pack wheels (`battery1Percent`)
+13. Battery 2 (%) — split-pack wheels (`battery2Percent`)
+14. Pitch angle (°) — tilt forward/back
+15. Roll angle (°) — lean left/right
+16. G-force combined (g) — phone IMU magnitude
+17. Lateral G (g) — `accelX`
+18. Forward G (g) — `accelY`
+19. Torque (`wheelData.torque`, unit TBD per protocol)
+20. Dynamic speed limit (km/h)
+21. Dynamic current limit (A)
+
+**Excluded (not useful as a grid card):**
+- Latitude / longitude — covered by Navigator, not a numeric readout.
+- Per-sensor temperatures (`temperatures: List<Float>`) — could be a Phase 8
+  multi-stat card; not v1.
+- Park/drive mode (`pcMode`) — boolean state already shown next to the gauge.
+
+Total: 21 metric options in v1, vs. 6 today.
+
+**Default `metricsSlots`** (matches the current dashboard so first launch is
+visually identical):
+
+```
+slot 1: BATTERY      center=CURRENT, others=NONE
+slot 2: TEMPERATURE  center=CURRENT, others=NONE
+slot 3: VOLTAGE      center=CURRENT, others=NONE
+slot 4: CURRENT      center=CURRENT, others=NONE   (long-press → WATTS)
+slot 5: LOAD         center=CURRENT, others=NONE
+slot 6: TRIP         center=CURRENT, others=NONE
+```
+
+---
+
+## 11. Expanded action inventory
+
+The picker in the action-slot bottom sheet is grouped by category. Categories
+keep a long list browsable on a phone-sized screen.
+
+**Wheel control** (from existing `FlicAction` enum + dashboard handlers):
+- Horn
+- Light toggle
+- Lock toggle
+- Legal mode toggle / Legal ON / Legal OFF (3 separate actions)
+
+**Recording** (`FlicAction` + `onNavigateToRecording`):
+- Record toggle
+- Record start
+- Record stop
+- Open recording screen
+
+**Voice** (existing handlers in `DashboardViewModel`):
+- Voice announce (one-shot)
+- Toggle periodic voice (existing long-press in menu)
+
+**Media** (existing `FlicAction`):
+- Play / Pause
+- Next track
+- Previous track
+
+**Shortcuts / Open…** (new "navigation" action category, mapping to existing
+`onNavigateTo*` callbacks):
+- Open Studio (overlay camera) — `onNavigateToStudio`
+- Open Navigator (map) — `onNavigateToNavigator`
+- Open Flic settings — `onNavigateToFlic`
+- Open Scan / Connect — `onNavigateToScan`
+- Open Trip detail (latest trip) — `onNavigateToTripDetail`
+- Open Settings → General (tab 0)
+- Open Settings → Display (tab 1 after reindex)
+- Open Settings → Speed (tab 2)
+- Open Settings → Voice (tab 3)
+- Open Settings → Alarms (tab 5)
+- Open Settings → Automations (tab 6)
+- Open Settings → Integration / Flic (tab 7)
+- Open Settings → Navigator (tab 8)
+- Open Metric history (per metric, parameterized) — `onNavigateToMetric("BATTERY")` etc.
+
+**None**:
+- Hide this slot (the button doesn't render at all, freeing visual space).
+
+Total: ~30 action options in v1, vs. 6 today.
+
+### Where the new actions live in code
+
+Add to `data/model/DashboardAction.kt` (created in Phase 1):
+
+```kotlin
+sealed interface DashboardAction {
+    val iconKey: String        // looked up by WatchActionMeta-style icon table
+    val labelRes: Int
+
+    // Wheel-control / Recording / Voice / Media — these map 1:1 to FlicAction.
+    data class Wheel(val flic: FlicAction): DashboardAction
+
+    // Navigation actions — open a screen, may carry a settings tab key.
+    data class OpenScreen(
+        val target: ScreenTarget,
+        val settingsTab: String? = null,
+        val metricKey: String? = null
+    ): DashboardAction
+
+    enum class ScreenTarget {
+        RECORDING, NAVIGATOR, STUDIO, SCAN, FLIC_SETTINGS,
+        TRIP_DETAIL_LATEST, SETTINGS_TAB, METRIC_DETAIL
+    }
+
+    data object None: DashboardAction
+}
+```
+
+This shape keeps Flic / Watch / Dashboard buttons reading from one vocabulary
+without coupling navigation callbacks into the Flic enum (Flic and Wear OS
+can't navigate the phone UI, so they only see `Wheel` variants — `OpenScreen`
+is dashboard-only).
+
+### Icon strategy
+
+- `Wheel` actions: re-use the icons from `WatchActionMeta.kt:26-37` exactly
+  (Horn = Campaign, Light = FlashlightOn, Lock = Lock, etc.).
+- `OpenScreen` actions: re-use the icon already used by the matching dashboard
+  affordance today — Studio = PhotoCamera, Navigator = Navigation, Scan =
+  Bluetooth, Flic settings = Extension, Settings tabs = the icon defined on
+  that tab in `SettingsScreen.kt:460-497`, Metric detail = the metric's
+  existing accent color + first-letter chip.
+
+No new icon assets needed — every action already has one somewhere in the
+codebase.
+
+---
+
+## 12. First-PR scope
+
+Phase 1 (the `DashboardAction` extraction) is the right first PR:
+
+- Pure refactor — no behavior change, no settings UI yet.
+- Touches DashboardScreen, FlicScreen, the watch's `WatchActionMeta`.
+- Easy to verify: `assembleDebug` + emulator smoke (boot, see same buttons /
+  metrics, tap each).
+
+After it merges, Phase 2 (read dashboard from `DashboardLayout` in
+`AppSettings`, still with defaults that reproduce today's layout) is the next
+PR. Everything user-visible starts in Phase 4.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.7.3"
 kotlin = "2.0.21"
 ksp = "2.0.21-1.0.28"
-composeBom = "2024.12.01"
+composeBom = "2025.04.01"
 hilt = "2.53.1"
 hiltNavigationCompose = "1.2.0"
 room = "2.6.1"

--- a/wear/src/main/java/com/eried/eucplanet/wear/ui/WatchActionMeta.kt
+++ b/wear/src/main/java/com/eried/eucplanet/wear/ui/WatchActionMeta.kt
@@ -1,6 +1,7 @@
 package com.eried.eucplanet.wear.ui
 
 import android.content.Context
+import androidx.annotation.StringRes
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Campaign
 import androidx.compose.material.icons.filled.FiberManualRecord
@@ -15,41 +16,42 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import com.eried.eucplanet.wear.R
 
 /**
- * Maps a [com.eried.eucplanet.data.model.FlicAction]-style action name (carried
- * across the Data Layer as a String) to an icon and a localized label the watch
- * can display.
+ * Watch-side icon + label registry, keyed by phone action key (the string
+ * the Data Layer carries from the phone).
  *
- * Kept in the wear module rather than imported from app/ because the watch
- * doesn't have a Hilt-injected dependency on AppSettings, it just needs the
- * String name. The action vocabulary mirrors `FlicAction` enum on the phone.
+ * KEEP IN SYNC with `com.eried.eucplanet.data.model.ActionCatalog` in the
+ * `app` module. The catalog is the single source of truth for which keys
+ * are eyes-free-safe (i.e. WATCH-bindable). The watch lives in its own
+ * Gradle module without an `app/` dependency, so this file maintains its
+ * own mapping — but the mapping is now consolidated into one table so the
+ * icon and label entries can never drift out of sync key-wise (adding an
+ * entry covers both). Labels stay watch-specific (`watch_action_*`) because
+ * the watch screen needs shorter strings than the phone's `action_chip_*`.
  */
-internal fun iconForAction(action: String): ImageVector? = when (action) {
-    "HORN" -> Icons.Filled.Campaign
-    "LIGHT_TOGGLE" -> Icons.Filled.FlashlightOn
-    "LOCK_TOGGLE" -> Icons.Filled.Lock
-    "SAFETY_TOGGLE", "SAFETY_ON", "SAFETY_OFF" -> Icons.Filled.Shield
-    "VOICE_ANNOUNCE" -> Icons.Filled.RecordVoiceOver
-    "RECORD_TOGGLE", "RECORD_START", "RECORD_STOP" -> Icons.Filled.FiberManualRecord
-    "MEDIA_PLAY_PAUSE" -> Icons.Filled.PlayArrow
-    "MEDIA_NEXT" -> Icons.Filled.SkipNext
-    "MEDIA_PREVIOUS" -> Icons.Filled.SkipPrevious
-    else -> null
-}
+private data class WatchActionEntry(
+    val icon: ImageVector,
+    @StringRes val labelRes: Int
+)
+
+private val WATCH_ACTION_TABLE: Map<String, WatchActionEntry> = mapOf(
+    "HORN" to WatchActionEntry(Icons.Filled.Campaign, R.string.watch_action_horn),
+    "LIGHT_TOGGLE" to WatchActionEntry(Icons.Filled.FlashlightOn, R.string.watch_action_light),
+    "LOCK_TOGGLE" to WatchActionEntry(Icons.Filled.Lock, R.string.watch_action_lock),
+    "SAFETY_TOGGLE" to WatchActionEntry(Icons.Filled.Shield, R.string.watch_action_safety),
+    "SAFETY_ON" to WatchActionEntry(Icons.Filled.Shield, R.string.watch_action_safety_on),
+    "SAFETY_OFF" to WatchActionEntry(Icons.Filled.Shield, R.string.watch_action_safety_off),
+    "VOICE_ANNOUNCE" to WatchActionEntry(Icons.Filled.RecordVoiceOver, R.string.watch_action_voice),
+    "RECORD_TOGGLE" to WatchActionEntry(Icons.Filled.FiberManualRecord, R.string.watch_action_record),
+    "RECORD_START" to WatchActionEntry(Icons.Filled.FiberManualRecord, R.string.watch_action_record_start),
+    "RECORD_STOP" to WatchActionEntry(Icons.Filled.FiberManualRecord, R.string.watch_action_record_stop),
+    "MEDIA_PLAY_PAUSE" to WatchActionEntry(Icons.Filled.PlayArrow, R.string.watch_action_media_play),
+    "MEDIA_NEXT" to WatchActionEntry(Icons.Filled.SkipNext, R.string.watch_action_media_next),
+    "MEDIA_PREVIOUS" to WatchActionEntry(Icons.Filled.SkipPrevious, R.string.watch_action_media_prev)
+)
+
+internal fun iconForAction(action: String): ImageVector? =
+    WATCH_ACTION_TABLE[action]?.icon
 
 /** Short user-facing label for the action, in the watch's locale. */
-internal fun labelForAction(context: Context, action: String): String? = when (action) {
-    "HORN" -> context.getString(R.string.watch_action_horn)
-    "LIGHT_TOGGLE" -> context.getString(R.string.watch_action_light)
-    "LOCK_TOGGLE" -> context.getString(R.string.watch_action_lock)
-    "SAFETY_TOGGLE" -> context.getString(R.string.watch_action_safety)
-    "SAFETY_ON" -> context.getString(R.string.watch_action_safety_on)
-    "SAFETY_OFF" -> context.getString(R.string.watch_action_safety_off)
-    "VOICE_ANNOUNCE" -> context.getString(R.string.watch_action_voice)
-    "RECORD_TOGGLE" -> context.getString(R.string.watch_action_record)
-    "RECORD_START" -> context.getString(R.string.watch_action_record_start)
-    "RECORD_STOP" -> context.getString(R.string.watch_action_record_stop)
-    "MEDIA_PLAY_PAUSE" -> context.getString(R.string.watch_action_media_play)
-    "MEDIA_NEXT" -> context.getString(R.string.watch_action_media_next)
-    "MEDIA_PREVIOUS" -> context.getString(R.string.watch_action_media_prev)
-    else -> null
-}
+internal fun labelForAction(context: Context, action: String): String? =
+    WATCH_ACTION_TABLE[action]?.labelRes?.let { context.getString(it) }


### PR DESCRIPTION
## Summary

Five-commit branch that lands the customizable dashboard, consolidates
the action layer behind a single catalog, and replaces the old metric
detail page with a unified tabbed History screen. Ships on top of the
em-dash sweep that `next-version` and `main` already share.

- **Action layer consolidated** behind `ActionCatalog` (eyes-free flag
  decides which surfaces an action lands on). FlicManager's executor
  drops the FlicAction enum and dispatches by string. Volume keys, Flic
  button picker, and the watch action picker all derive from the
  catalog.
- **MetricCatalog** is the parallel single source of truth for metrics
  (label, accent, sparkline style, supports-stats flag). The editor's
  helpers collapse to one-line catalog reads.
- **Customizable dashboard editor**: drag/swap/hide, build composite
  multi-metric tiles (2-row / 2-col / 3-col with per-cell stat picker),
  custom tiles (text + URL + QR), and action groups (popover with sub-
  actions). Pool is an alphabetical catalog (copy-into-grid, never
  consumed). Default layout matches the old hardcoded grid byte-for-
  byte so a fresh install looks identical.
- **Live dashboard runtime** reads layout from settings and renders via
  `LiveMetricTile` with all five sparkline styles (LINE / SMOOTH /
  AREA / AREA_BIPOLAR / NONE). Composite + custom tile + action group
  popover all wired with sized-to-anchor buttons, scale-in animation,
  and side-tap detection to preselect the History tab.
- **Unified History screen** takes any list of metric keys + an
  initial tab index. Stats region is three accent-tinted MIN/AVG/MAX
  pills plus a thin row of MEDIAN/P95/N/TIME. Reset is a small pill
  button with long-press for "Reset all" confirm.
- **Service-mode debug overlay** opens on volume key while diagnostics
  is enabled. Compact "Debug" sheet with metric + action combos that
  reflect on the catalog metadata and fire any action via the shared
  dispatch path.

## Compatibility

Old → new build: zero issues (missing fields default to empty / "{}").
New → old build: customization is silently dropped on the next save
(unknown JSON keys lost on rewrite). No data corruption either way.

## Test plan

- [ ] Fresh install -> dashboard renders the default BATTERY / TEMP /
      VOLTAGE / CURRENT / LOAD / TRIP grid and HORN / LIGHT / VOICE /
      SAFETY / LOCK / RECORD action row identically to pre-PR
- [ ] Editor: drag a metric to a new slot, swap two metrics, drop a
      static metric onto the pool -> turns into an empty custom tile
- [ ] Composite tile: pick MAX for one of three cells -> grid shows
      MAX label above the metric in the composite cell, value pulls
      from rolling history
- [ ] Single-metric tile tap -> History opens on the matching tab
- [ ] Composite tile side-tap on the right third -> History opens on
      the third tab, tab order preserved
- [ ] Action group tap -> popover surfaces above the tile (25% overlap),
      sub-action tiles match the dashboard button size, scale-in
      animation plays
- [ ] Long-press Reset on History -> "Reset all history?" confirm
- [ ] Settings -> About -> Enter service mode -> volume key opens the
      Debug overlay; tap Action dropdown -> Fire HORN -> action fires,
      logcat shows `executeAction key=HORN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)