### PR TITLE
Merge fix/LK19486-horn into next-version

### DIFF
--- a/app/src/main/java/com/eried/eucplanet/ble/CompositeWheelAdapter.kt
+++ b/app/src/main/java/com/eried/eucplanet/ble/CompositeWheelAdapter.kt
@@ -98,7 +98,9 @@ class CompositeWheelAdapter @Inject constructor(
     override fun pollSettings(): ByteArray = active.pollSettings()
 
     override fun horn(): ByteArray? = active.horn()
+    override fun hornFollowup(): ByteArray? = active.hornFollowup()
     override fun setLight(on: Boolean): ByteArray? = active.setLight(on)
+    override fun setLightFollowup(on: Boolean): ByteArray? = active.setLightFollowup(on)
     override fun setMaxSpeed(tiltbackKmh: Float, alarmKmh: Float): ByteArray? =
         active.setMaxSpeed(tiltbackKmh, alarmKmh)
     override fun setMaxSpeedCommit(tiltbackKmh: Float): ByteArray? =

--- a/app/src/main/java/com/eried/eucplanet/ble/VeteranAdapter.kt
+++ b/app/src/main/java/com/eried/eucplanet/ble/VeteranAdapter.kt
@@ -56,6 +56,16 @@ class VeteranAdapter @Inject constructor() : WheelAdapter {
     override fun horn(): ByteArray = VeteranCommands.horn()
 
     /**
+     * Current Lynx-class firmware only sounds the horn when the `LkAp` frame
+     * from [horn] is followed by this `LdAp` companion. WheelLog sends just the
+     * `LkAp` half, so its horn is silently ignored on these wheels (the frame is
+     * accepted but produces no beep). Decoded from a LeaperKim-app btsnoop on a
+     * Lynx S (mVer 9). [com.eried.eucplanet.data.repository.WheelRepository.sendHorn]
+     * writes both, in order.
+     */
+    override fun hornFollowup(): ByteArray = VeteranCommands.hornCompanion()
+
+    /**
      * Light state is never echoed in Veteran realtime frames (per
      * docs/protocols/veteran.md §6: "Light state has no readback.
      * Track it locally after each write."). We cache the last
@@ -71,8 +81,22 @@ class VeteranAdapter @Inject constructor() : WheelAdapter {
 
     override fun setLight(on: Boolean): ByteArray {
         lastLightOn = on
-        return VeteranCommands.setLight(on)
+        // HIGH beam by default (LkAp frame; LdAp companion via [setLightFollowup]).
+        return VeteranCommands.setHighBeam(on)
+        // LOW beam (legacy ASCII, single frame). To switch the in-app light
+        // toggle back to the low beam: comment the high-beam return above,
+        // uncomment the line below, and make [setLightFollowup] return null.
+        // return VeteranCommands.setLight(on)
     }
+
+    /**
+     * Second frame of the high-beam command (`LdAp`); the wheel ignores the
+     * `LkAp` half from [setLight] on its own. Decoded from the same Lynx S
+     * btsnoop as the horn. If you switch [setLight] back to the low beam,
+     * change this to `null` (low beam is a single ASCII frame).
+     */
+    override fun setLightFollowup(on: Boolean): ByteArray =
+        VeteranCommands.setHighBeamCompanion(on)
 
     // Veteran writes tilt-back and alarm thresholds as two separate frames
     // (different magic + sub-op per setting), so we leave the combined

--- a/app/src/main/java/com/eried/eucplanet/ble/VeteranCommands.kt
+++ b/app/src/main/java/com/eried/eucplanet/ble/VeteranCommands.kt
@@ -15,26 +15,42 @@ package com.eried.eucplanet.ble
 object VeteranCommands {
 
     /**
-     * Horn for `model >= 3` (Sherman S, Patton, Lynx, Abrams, Oryx, Nosfet).
-     * The blob is byte-for-byte what the wheel expects; bytes 4..13 are not
-     * publicly understood (possibly a session tag or feature-negotiation
-     * stub) but replay works in practice. Sherman / pre-2020 firmwares
-     * accept the legacy single-byte `b` instead, not exposed here because
-     * we can't reliably tell them apart before the first telemetry frame
-     * lands. The blob is silently ignored on `model < 3`, which is the
-     * safer default until we wire model-aware horn dispatch.
+     * Horn — first of a TWO-frame command on current LeaperKim firmware.
      *
-     * Spec: docs/protocols/veteran.md section 6, "Beep (firmware model >= 3)".
+     * A Lynx S btsnoop (mVer 9, May 2026) shows the official app sounds the horn
+     * by writing this `LkAp` frame immediately followed by the [hornCompanion]
+     * `LdAp` frame. WheelLog and older EUC Planet builds send only this `LkAp`
+     * half; Lynx-class firmware accepts it (the CRC32 is valid) but does NOT beep
+     * on it alone — confirmed in the field where the blob reached the wheel four
+     * times with no sound. Always send [horn] then [hornCompanion].
+     *
+     * Wire: `4c 6b 41 70 0e 00 80 80 80 01 ca 87 e6 6f` — a 14-byte vendor frame
+     * (payload `00 80 80 80 01`, big-endian CRC32 trailer), identical to the byte
+     * blob WheelLog hard-codes. Pre-2020 Sherman (model < 3) instead take the
+     * single byte [hornLegacy].
+     *
+     * Spec: docs/protocols/veteran.md section 6, "Beep".
      */
-    private val HORN_BLOB_V3: ByteArray = byteArrayOf(
-        0x4C, 0x6B, 0x41, 0x70,
-        0x0E, 0x00, 0x80.toByte(), 0x80.toByte(),
-        0x80.toByte(), 0x01, 0xCA.toByte(), 0x87.toByte(),
-        0xE6.toByte(), 0x6F
+    fun horn(): ByteArray = buildVendorFrame(
+        magic = LKAP, totalLen = 14,
+        payloadHead = byteArrayOf(0x00, 0x80.toByte(), 0x80.toByte(), 0x80.toByte()),
+        valueByte = 0x01
     )
 
-    /** 14-byte horn blob. See [HORN_BLOB_V3] for the model-coverage caveat. */
-    fun horn(): ByteArray = HORN_BLOB_V3.copyOf()
+    /**
+     * Second frame of the horn (`LdAp`), required by current Lynx-class firmware;
+     * see [horn] for why the `LkAp` frame alone doesn't beep. Sent right after
+     * [horn] as a separate BLE write (the official app splits the pair the same
+     * way at the 20-byte ATT boundary).
+     *
+     * Wire: `4c 64 41 70 0e 00 00 80 80 01 f8 67 9f 85` — 14-byte vendor frame
+     * (payload `00 00 80 80 01`, big-endian CRC32 trailer).
+     */
+    fun hornCompanion(): ByteArray = buildVendorFrame(
+        magic = LDAP, totalLen = 14,
+        payloadHead = byteArrayOf(0x00, 0x00, 0x80.toByte(), 0x80.toByte()),
+        valueByte = 0x01
+    )
 
     /**
      * Legacy single-byte horn `b` (0x62) for `model < 3` firmwares (original
@@ -47,10 +63,32 @@ object VeteranCommands {
      */
     fun hornLegacy(): ByteArray = byteArrayOf(0x62)
 
-    /** Light on / off. ASCII strings the wheel matches verbatim. */
+    /** Low-beam on / off. ASCII strings the wheel matches verbatim. */
     fun setLight(on: Boolean): ByteArray =
         if (on) "SetLightON".toByteArray(Charsets.US_ASCII)
         else "SetLightOFF".toByteArray(Charsets.US_ASCII)
+
+    /**
+     * High beam on/off — the LeaperKim binary headlight command (`LkAp` frame;
+     * companion `LdAp` in [setHighBeamCompanion]). Captured from the LeaperKim
+     * app on a Lynx S: a 13-byte vendor frame, payload `01 80 80 <state>`, state
+     * `01`=on / `00`=off. This is a SEPARATE light from the ASCII [setLight] low
+     * beam — the wheel drives the two independently. Send [setHighBeam] then
+     * [setHighBeamCompanion] (the wheel ignores the `LkAp` half on its own, same
+     * as the horn). See docs/protocols/veteran.md section 6.2.
+     */
+    fun setHighBeam(on: Boolean): ByteArray = buildVendorFrame(
+        magic = LKAP, totalLen = 13,
+        payloadHead = byteArrayOf(0x01, 0x80.toByte(), 0x80.toByte()),
+        valueByte = if (on) 0x01 else 0x00
+    )
+
+    /** Companion `LdAp` frame for [setHighBeam]; payload `01 00 80 <state>`. */
+    fun setHighBeamCompanion(on: Boolean): ByteArray = buildVendorFrame(
+        magic = LDAP, totalLen = 13,
+        payloadHead = byteArrayOf(0x01, 0x00, 0x80.toByte()),
+        valueByte = if (on) 0x01 else 0x00
+    )
 
     /**
      * Pedal stiffness: hard / medium / soft. Veteran does not expose ride

--- a/app/src/main/java/com/eried/eucplanet/ble/WheelAdapter.kt
+++ b/app/src/main/java/com/eried/eucplanet/ble/WheelAdapter.kt
@@ -144,7 +144,25 @@ interface WheelAdapter {
 
     // --- Control commands. Return null if the wheel doesn't support the action. ---
     fun horn(): ByteArray?
+
+    /**
+     * Optional second frame sent immediately after [horn]. Veteran's current
+     * (Lynx-class) firmware only beeps when the `LkAp` horn frame is followed
+     * by an `LdAp` companion frame, so [VeteranAdapter] returns it here. Default
+     * null for families whose horn is a single write.
+     */
+    fun hornFollowup(): ByteArray? = null
+
     fun setLight(on: Boolean): ByteArray?
+
+    /**
+     * Optional second frame sent immediately after [setLight], for families
+     * whose headlight command is a two-frame write. Veteran drives the high
+     * beam as an `LkAp` + `LdAp` pair, so [VeteranAdapter] returns the `LdAp`
+     * companion here. Default null (single-write headlight).
+     */
+    fun setLightFollowup(on: Boolean): ByteArray? = null
+
     fun setMaxSpeed(tiltbackKmh: Float, alarmKmh: Float): ByteArray?
 
     /**

--- a/app/src/main/java/com/eried/eucplanet/data/model/AppSettings.kt
+++ b/app/src/main/java/com/eried/eucplanet/data/model/AppSettings.kt
@@ -597,6 +597,17 @@ data class AppSettings(
     val dashboardCustomTiles: String = "{}",
 
     /**
+     * Custom BLE action definitions as a JSON object keyed by `B:<uuid>`. Each
+     * value is `{ "label": <text>, "icon": <icon_key>, "family": <familyId>,
+     * "frames": [<hex>, ...] }`. Frames are written verbatim (one BLE write each,
+     * in order) to the connected wheel, but only when its family matches; the id
+     * appears in [dashboardActionOrder] like a built-in action key. Opt-in for
+     * advanced users — empty object until a rider drags the CUSTOM BLE template.
+     * See [com.eried.eucplanet.data.model.CustomBleCommand].
+     */
+    val dashboardCustomBle: String = "{}",
+
+    /**
      * Per-metric corner-stat configuration as a JSON object. Each known metric
      * key maps to a config object with five stat slots (center, top-left,
      * top-right, bottom-left, bottom-right) and a sparkline flag. Defaults are

--- a/app/src/main/java/com/eried/eucplanet/data/model/CustomBleCommand.kt
+++ b/app/src/main/java/com/eried/eucplanet/data/model/CustomBleCommand.kt
@@ -132,7 +132,7 @@ data class CustomBleCommand(
                 out[key] = CustomBleCommand(
                     id = key,
                     label = v.optString("label", ""),
-                    iconKey = v.optString("icon", "Campaign"),
+                    iconKey = v.optString("icon", "BOLT"),
                     family = v.optString("family", ""),
                     frames = frames
                 )

--- a/app/src/main/java/com/eried/eucplanet/data/model/CustomBleCommand.kt
+++ b/app/src/main/java/com/eried/eucplanet/data/model/CustomBleCommand.kt
@@ -1,0 +1,161 @@
+package com.eried.eucplanet.data.model
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * A user-defined "CUSTOM BLE" action: an ordered list of raw frames written to
+ * the connected wheel when the rider taps the button. Write-only.
+ *
+ * Scoped to a wheel [family] (an adapter `familyId` such as "veteran"); it is
+ * only dispatched when the connected wheel matches, so custom bytes never reach
+ * a wheel they were not authored for. Persisted in
+ * [AppSettings.dashboardCustomBle] as a JSON object keyed by [id] ("B:<uuid>"),
+ * mirroring the `dashboardCustomTiles` ("C:<uuid>") pattern. The id also appears
+ * in `dashboardActionOrder` like a built-in action key.
+ *
+ * Frames are sent verbatim (one BLE write each, in order) — the user pastes
+ * complete frames, typically copied from a btsnoop, so any required CRC is
+ * already baked in. See docs/superpowers/specs/2026-06-01-custom-ble-action-design.md.
+ */
+data class CustomBleCommand(
+    val id: String,
+    val label: String,
+    val iconKey: String,
+    val family: String,
+    val frames: List<ByteArray>
+) {
+    /** At least one non-empty frame to send. A command with none is a no-op. */
+    val isSendable: Boolean get() = frames.any { it.isNotEmpty() }
+
+    // Explicit equals/hashCode because [frames] is a List<ByteArray] (reference
+    // equality by default). Mirrors VeteranParser.Frame.
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is CustomBleCommand) return false
+        return id == other.id && label == other.label && iconKey == other.iconKey &&
+            family == other.family && frames.size == other.frames.size &&
+            frames.indices.all { frames[it].contentEquals(other.frames[it]) }
+    }
+
+    override fun hashCode(): Int {
+        var h = id.hashCode()
+        h = 31 * h + label.hashCode()
+        h = 31 * h + iconKey.hashCode()
+        h = 31 * h + family.hashCode()
+        frames.forEach { h = 31 * h + it.contentHashCode() }
+        return h
+    }
+
+    companion object {
+        const val ID_PREFIX = "B:"
+
+        fun isCustomBleId(key: String): Boolean = key.startsWith(ID_PREFIX)
+
+        /** A fresh synthetic id; pass a UUID string the caller already holds. */
+        fun newId(uuid: String): String = ID_PREFIX + uuid
+
+        /**
+         * Pure dispatch gate: resolve [key] to a command that is safe to send on
+         * the currently connected wheel. Returns null (caller no-ops) when the key
+         * is unknown, the command has no sendable frames, the wheel is
+         * disconnected, or the command targets a different [family] than
+         * [connectedFamily]. Keeps raw bytes from reaching a wheel they were not
+         * authored for.
+         */
+        fun resolveForDispatch(
+            commands: Map<String, CustomBleCommand>,
+            key: String,
+            connectedFamily: String?
+        ): CustomBleCommand? {
+            val cmd = commands[key] ?: return null
+            if (!cmd.isSendable) return null
+            if (connectedFamily == null || cmd.family != connectedFamily) return null
+            return cmd
+        }
+
+        /**
+         * Parse one hex frame. Accepts spaces, commas, colons, semicolons,
+         * underscores, dashes and "0x" prefixes between bytes; case-insensitive.
+         * Returns null if any non-hex character remains or the nibble count is
+         * odd, so the editor can reject bad input.
+         */
+        fun parseHexFrame(text: String): ByteArray? {
+            val cleaned = text
+                .replace("0x", "", ignoreCase = true)
+                .replace(Regex("[\\s,:;_-]"), "")
+            if (cleaned.isEmpty() || cleaned.length % 2 != 0) return null
+            if (!cleaned.all { it.isDigit() || it in 'a'..'f' || it in 'A'..'F' }) return null
+            return ByteArray(cleaned.length / 2) {
+                cleaned.substring(it * 2, it * 2 + 2).toInt(16).toByte()
+            }
+        }
+
+        /**
+         * Parse a multiline frames blob: one frame per non-blank line. Returns
+         * null if ANY non-blank line fails to parse (editor rejects the whole
+         * input); all-blank input yields an empty list.
+         */
+        fun parseFrames(text: String): List<ByteArray>? {
+            val out = ArrayList<ByteArray>()
+            for (raw in text.lines()) {
+                val line = raw.trim()
+                if (line.isEmpty()) continue
+                out.add(parseHexFrame(line) ?: return null)
+            }
+            return out
+        }
+
+        fun bytesToHex(b: ByteArray): String = b.joinToString(" ") { "%02x".format(it) }
+
+        fun framesToText(frames: List<ByteArray>): String =
+            frames.joinToString("\n") { bytesToHex(it) }
+
+        /**
+         * Parse every command from the `dashboardCustomBle` JSON string. Malformed
+         * JSON or entries yield an empty map / skipped entry rather than throwing,
+         * matching the lenient read pattern of the sibling dashboard tile fields.
+         */
+        fun parseAll(json: String): Map<String, CustomBleCommand> {
+            if (json.isBlank()) return emptyMap()
+            val obj = try { JSONObject(json) } catch (e: Exception) { return emptyMap() }
+            val out = LinkedHashMap<String, CustomBleCommand>()
+            for (key in obj.keys()) {
+                val v = obj.optJSONObject(key) ?: continue
+                val arr = v.optJSONArray("frames")
+                val frames = ArrayList<ByteArray>()
+                if (arr != null) {
+                    for (i in 0 until arr.length()) {
+                        parseHexFrame(arr.optString(i))?.let { frames.add(it) }
+                    }
+                }
+                out[key] = CustomBleCommand(
+                    id = key,
+                    label = v.optString("label", ""),
+                    iconKey = v.optString("icon", "Campaign"),
+                    family = v.optString("family", ""),
+                    frames = frames
+                )
+            }
+            return out
+        }
+
+        /** Serialize commands back to the `dashboardCustomBle` JSON string. */
+        fun serialize(commands: Collection<CustomBleCommand>): String {
+            val obj = JSONObject()
+            for (c in commands) {
+                val arr = JSONArray()
+                c.frames.forEach { arr.put(bytesToHex(it)) }
+                obj.put(
+                    c.id,
+                    JSONObject()
+                        .put("label", c.label)
+                        .put("icon", c.iconKey)
+                        .put("family", c.family)
+                        .put("frames", arr)
+                )
+            }
+            return obj.toString()
+        }
+    }
+}

--- a/app/src/main/java/com/eried/eucplanet/data/repository/WheelRepository.kt
+++ b/app/src/main/java/com/eried/eucplanet/data/repository/WheelRepository.kt
@@ -481,6 +481,10 @@ class WheelRepository @Inject constructor(
 
     fun sendHorn() {
         wheelAdapter.horn()?.let { bleManager.writeCommand(it) }
+        // Veteran (Lynx-class) needs an LdAp companion frame right after the
+        // LkAp horn or the wheel stays silent; queued as a second write so it
+        // lands in order. Null for every other family (single-frame horn).
+        wheelAdapter.hornFollowup()?.let { bleManager.writeCommand(it) }
     }
 
     /**
@@ -504,6 +508,10 @@ class WheelRepository @Inject constructor(
             "toggleLight: lightOn was=$current, sending $next"
         )
         wheelAdapter.setLight(next)?.let { bleManager.writeCommand(it) }
+        // Veteran high beam needs an LdAp companion frame right after the LkAp
+        // frame; queued as a second write so it lands in order. Null for the
+        // ASCII low beam and every other family (single-frame headlight).
+        wheelAdapter.setLightFollowup(next)?.let { bleManager.writeCommand(it) }
         _wheelData.value = _wheelData.value.copy(lightOn = next)
         startCooldown(_lightBusy, LIGHT_COOLDOWN_MS) { lightCooldownUntilMs = it }
     }

--- a/app/src/main/java/com/eried/eucplanet/data/repository/WheelRepository.kt
+++ b/app/src/main/java/com/eried/eucplanet/data/repository/WheelRepository.kt
@@ -488,6 +488,21 @@ class WheelRepository @Inject constructor(
     }
 
     /**
+     * The connected wheel's adapter family id ("veteran", "kingsong", ...), or
+     * null when disconnected. Gates family-scoped custom BLE commands so raw
+     * user bytes never reach a wheel they were not authored for.
+     */
+    val connectedFamilyId: String?
+        get() = if (bleManager.connectionState.value == ConnectionState.CONNECTED) {
+            wheelAdapter.familyId
+        } else null
+
+    /** Write a custom BLE command's frames verbatim — one BLE write each, in order. */
+    fun sendCustomBle(frames: List<ByteArray>) {
+        frames.forEach { if (it.isNotEmpty()) bleManager.writeCommand(it) }
+    }
+
+    /**
      * Send the family-specific "reset trip meter" command. Returns true when
      * the active adapter has a documented command (the wheel takes a frame or
      * two to zero offset 8..11 in its realtime stream); false when the

--- a/app/src/main/java/com/eried/eucplanet/data/store/SettingsJson.kt
+++ b/app/src/main/java/com/eried/eucplanet/data/store/SettingsJson.kt
@@ -224,6 +224,7 @@ object SettingsJson {
         put("dashboardCompositeMetrics", s.dashboardCompositeMetrics)
         put("dashboardActionGroups", s.dashboardActionGroups)
         put("dashboardCustomTiles", s.dashboardCustomTiles)
+        put("dashboardCustomBle", s.dashboardCustomBle)
     }
 
     fun fromJson(j: JSONObject, base: AppSettings = AppSettings()): AppSettings = base.copy(
@@ -423,7 +424,8 @@ object SettingsJson {
         dashboardMetricStats = j.optString("dashboardMetricStats", base.dashboardMetricStats),
         dashboardCompositeMetrics = j.optString("dashboardCompositeMetrics", base.dashboardCompositeMetrics),
         dashboardActionGroups = j.optString("dashboardActionGroups", base.dashboardActionGroups),
-        dashboardCustomTiles = j.optString("dashboardCustomTiles", base.dashboardCustomTiles)
+        dashboardCustomTiles = j.optString("dashboardCustomTiles", base.dashboardCustomTiles),
+        dashboardCustomBle = j.optString("dashboardCustomBle", base.dashboardCustomBle)
     )
 
     /** `optString` returns `""` for null and absent keys, which we cannot

--- a/app/src/main/java/com/eried/eucplanet/flic/FlicManager.kt
+++ b/app/src/main/java/com/eried/eucplanet/flic/FlicManager.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import android.view.KeyEvent
 import com.eried.eucplanet.R
 import com.eried.eucplanet.data.model.AppSettings
+import com.eried.eucplanet.data.model.CustomBleCommand
 import com.eried.eucplanet.data.repository.SettingsRepository
 import com.eried.eucplanet.data.repository.TripRepository
 import com.eried.eucplanet.data.repository.WheelRepository
@@ -272,10 +273,32 @@ class FlicManager @Inject constructor(
      * route through a different executor in the UI layer because they need
      * navigation / Snackbar / Compose handles this service doesn't have.
      */
+    /**
+     * Resolve and fire a CUSTOM BLE action (key "B:<uuid>"). Family-gated: a
+     * command only fires on a matching connected wheel, so raw user bytes never
+     * reach the wrong wheel. No-op (logged) otherwise.
+     */
+    private fun dispatchCustomBle(key: String, settings: AppSettings) {
+        val commands = CustomBleCommand.parseAll(settings.dashboardCustomBle)
+        val cmd = CustomBleCommand.resolveForDispatch(
+            commands, key, wheelRepository.connectedFamilyId
+        )
+        if (cmd == null) {
+            Log.i(TAG, "custom BLE $key skipped: no match / wrong wheel / empty")
+            return
+        }
+        Log.i(TAG, "custom BLE $key -> ${cmd.frames.size} frame(s) on ${cmd.family}")
+        wheelRepository.sendCustomBle(cmd.frames)
+    }
+
     private suspend fun executeAction(key: String, settings: AppSettings) {
         if (key.isEmpty() || key == "NONE") return
         _lastActionAt.value = System.currentTimeMillis()
         Log.d(TAG, "executeAction key=$key")
+        if (CustomBleCommand.isCustomBleId(key)) {
+            dispatchCustomBle(key, settings)
+            return
+        }
         when (key) {
             "HORN" -> wheelRepository.sendHorn()
             "LIGHT_TOGGLE" -> {

--- a/app/src/main/java/com/eried/eucplanet/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/eried/eucplanet/ui/dashboard/DashboardScreen.kt
@@ -247,6 +247,7 @@ fun DashboardScreen(
     val dashboardCustomTilesJson by viewModel.dashboardCustomTiles.collectAsState()
     val dashboardActionOrderRaw by viewModel.dashboardActionOrder.collectAsState()
     val dashboardActionGroupsJson by viewModel.dashboardActionGroups.collectAsState()
+    val dashboardCustomBleJson by viewModel.dashboardCustomBle.collectAsState()
     // Phone-battery and GPS feeds for the catalog metrics that aren't
     // sourced from WheelData. Both update lazily; the value pipeline
     // just reads the latest StateFlow snapshot on each recomposition.
@@ -1885,6 +1886,42 @@ fun DashboardScreen(
                                 // lives in the settings module; for
                                 // now the tap is a no-op so the rider
                                 // still sees a recognisable tile.
+                                key.startsWith("B:") -> {
+                                    // Custom BLE command instance (B:uuid).
+                                    // Reads the rider's label + icon from
+                                    // dashboardCustomBleJson; tap dispatches
+                                    // through the shared FlicManager path,
+                                    // which family-gates the raw frames.
+                                    val parsedBle = remember(dashboardCustomBleJson, key) {
+                                        try {
+                                            val root = org.json.JSONObject(
+                                                dashboardCustomBleJson.ifBlank { "{}" }
+                                            )
+                                            val node = root.optJSONObject(key)
+                                            val lbl = node?.optString("label", "") ?: ""
+                                            val ic = node?.optString("icon", "BOLT") ?: "BOLT"
+                                            Pair(lbl, ic)
+                                        } catch (_: Exception) {
+                                            Pair("", "BOLT")
+                                        }
+                                    }
+                                    val (bleLabel, bleIcon) = parsedBle
+                                    val bleDefault = stringResource(
+                                        R.string.dashboard_custom_ble_default_name
+                                    )
+                                    Box(modifier = Modifier.weight(1f)) {
+                                        ActionButton(
+                                            icon = com.eried.eucplanet.ui.settings.groupIconFor(
+                                                bleIcon.ifBlank { "BOLT" }
+                                            ),
+                                            label = bleLabel.ifBlank { bleDefault },
+                                            enabled = true,
+                                            onClick = { viewModel.dispatchActionByName(key) },
+                                            modifier = Modifier.fillMaxWidth(),
+                                            aspectRatio = actionAspect, heightDp = actionHeight
+                                        )
+                                    }
+                                }
                                 key.startsWith("G:") -> {
                                     // Parse the group definition once per
                                     // change to the groups JSON. Name +

--- a/app/src/main/java/com/eried/eucplanet/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/eried/eucplanet/ui/dashboard/DashboardViewModel.kt
@@ -384,6 +384,10 @@ class DashboardViewModel @Inject constructor(
         .map { it.dashboardActionGroups }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000),
             initialSettings.dashboardActionGroups)
+    val dashboardCustomBle: StateFlow<String> = settingsRepository.settings
+        .map { it.dashboardCustomBle }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000),
+            initialSettings.dashboardCustomBle)
 
     /** Fires an action by its catalog key via FlicManager — shared dispatch with Flic / volume / watch. */
     fun dispatchActionByName(key: String) = flicManager.dispatchActionByName(key)

--- a/app/src/main/java/com/eried/eucplanet/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/eried/eucplanet/ui/settings/SettingsScreen.kt
@@ -1135,9 +1135,6 @@ private fun DashboardLayoutTab(
                     s.left != DashboardStat.NONE || s.right != DashboardStat.NONE || s.sparkline
                 },
                 onTap = { _ -> showPoolTapToast() },
-                onDeleteComposite = { id -> viewModel.deleteCompositeMetric(id) },
-                onDeleteCustomTile = { id -> viewModel.deleteCustomTile(id) },
-                onDemoteMetric = { key -> viewModel.demoteMetricToCustomTile(key) },
                 controller = dragController
             )
         }
@@ -1181,8 +1178,6 @@ private fun DashboardLayoutTab(
             ActionPool(
                 catalogKeys = viewModel.knownDashboardActions,
                 onTap = { _ -> showPoolTapToast() },
-                onDeleteGroup = { id -> viewModel.deleteActionGroup(id) },
-                onDeleteCustomBle = { id -> viewModel.deleteCustomBle(id) },
                 controller = dragController
             )
         }
@@ -1996,9 +1991,6 @@ private fun MetricPool(
     valueOf: (String) -> String,
     statsEnabledOf: (String) -> Boolean,
     onTap: (String) -> Unit,
-    onDeleteComposite: (String) -> Unit,
-    onDeleteCustomTile: (String) -> Unit,
-    onDemoteMetric: (String) -> Unit,
     controller: DashboardDragController
 ) {
     // metricChipLabel is @Composable (reads string resources), so resolve
@@ -2031,38 +2023,10 @@ private fun MetricPool(
                 expectedSizePx = poolPillSizePx,
                 controller = controller
             )
-            // Pool handles three different "back to pool" actions in one
-            // drop target, distinguished by the source key:
-            //  - Composite tile → delete the composite definition
-            //  - Custom tile → delete the custom-tile definition
-            //  - Regular metric in active grid → demote: metric goes to the
-            //    pool, a fresh empty custom tile spawns in its place
-            // Template drags (COMPOSITE_TEMPLATE_KEY / CUSTOM_TILE_TEMPLATE_KEY)
-            // are rejected so dragging a template back here doesn't double-
-            // spawn anything. overrideExpectedSizePx shrinks the floating
-            // preview to pool-pill size on hover so the rider sees the
-            // "going back to pool" affordance regardless of which case fires.
-            .dashboardDropTarget(
-                key = "metric-pool-trash",
-                kind = DropKind.METRIC_POOL_TRASH,
-                controller = controller,
-                onDrop = { sourceKey ->
-                    // Only fire when the source was a big grid tile.
-                    // Pool→pool drags are no-ops (catalog stays full).
-                    if (controller.sourceFromGrid) {
-                        when {
-                            isCompositeMetricKey(sourceKey) -> onDeleteComposite(sourceKey)
-                            isCustomTileKey(sourceKey) -> onDeleteCustomTile(sourceKey)
-                            else -> onDemoteMetric(sourceKey)
-                        }
-                    }
-                },
-                acceptsSourceKey = { sourceKey ->
-                    sourceKey != COMPOSITE_TEMPLATE_KEY &&
-                        sourceKey != CUSTOM_TILE_TEMPLATE_KEY
-                },
-                overrideExpectedSizePx = poolPillSizePx
-            )
+            // No pool drop target: dragging a big tile out to the pool is a
+            // no-op (it snaps back). Dynamic instances are deleted from the
+            // slot editor (Reset slot), keeping behaviour consistent with the
+            // action grid.
             .verticalScroll(rememberScrollState())
             .padding(8.dp)
     ) {
@@ -2074,10 +2038,10 @@ private fun MetricPool(
             // available source. Dragging it onto a grid slot spawns a new
             // composite instance.
             MetricCompositeTemplatePill(controller = controller)
-            // CustomTileTemplatePill is intentionally hidden — riders create
-            // custom tiles implicitly by dragging a regular metric back to
-            // the pool. The template pill code is preserved so we can
-            // re-surface it later if we want explicit creation.
+            // Explicit custom-tile creation (text / link / QR). Drag-to-pool
+            // demote was removed for consistency, so this template is now the
+            // only way to add one — sits next to the + Stack composite source.
+            CustomTileTemplatePill(controller = controller)
             sorted.forEach { key ->
                 MetricPoolPill(
                     key = key,
@@ -2962,8 +2926,6 @@ private fun CustomBleTile(
 private fun ActionPool(
     catalogKeys: List<String>,
     onTap: (String) -> Unit,
-    onDeleteGroup: (String) -> Unit,
-    onDeleteCustomBle: (String) -> Unit,
     controller: DashboardDragController
 ) {
     val labeled = catalogKeys.map { it to actionChipLabel(it) }
@@ -2984,30 +2946,9 @@ private fun ActionPool(
                 expectedSizePx = poolPillSizePx,
                 controller = controller
             )
-            // Trash for action-group instances. The predicate ensures regular
-            // pool pills and the template drag pass through unaffected, and
-            // overrideExpectedSizePx previews the tile shrinking to pool-pill
-            // size so the rider sees "this is being deleted" instead of the
-            // tile growing to fill the whole pool.
-            .dashboardDropTarget(
-                key = "action-pool-trash",
-                kind = DropKind.ACTION_POOL_TRASH,
-                controller = controller,
-                onDrop = { sourceKey ->
-                    // Only grid-sourced dynamic instances get deleted. Static
-                    // actions can't be removed from the catalog; pool→pool
-                    // drags are no-ops by the same rule.
-                    if (controller.sourceFromGrid && isActionGroupKey(sourceKey)) {
-                        onDeleteGroup(sourceKey)
-                    } else if (controller.sourceFromGrid && isCustomBleKey(sourceKey)) {
-                        onDeleteCustomBle(sourceKey)
-                    }
-                },
-                acceptsSourceKey = { sourceKey ->
-                    isActionGroupKey(sourceKey) || isCustomBleKey(sourceKey)
-                },
-                overrideExpectedSizePx = poolPillSizePx
-            )
+            // No pool drop target: dragging a big tile out to the pool is a
+            // no-op (it snaps back). Group / custom-BLE instances are deleted
+            // from the slot editor (Reset slot).
             .verticalScroll(rememberScrollState())
             .padding(8.dp)
     ) {

--- a/app/src/main/java/com/eried/eucplanet/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/eried/eucplanet/ui/settings/SettingsScreen.kt
@@ -3835,21 +3835,36 @@ private fun CustomBleSheet(
                 )
             }
 
-            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                Text(
-                    stringResource(R.string.dashboard_custom_ble_family),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+            var familyExpanded by remember { mutableStateOf(false) }
+            androidx.compose.material3.ExposedDropdownMenuBox(
+                expanded = familyExpanded,
+                onExpandedChange = { familyExpanded = it }
+            ) {
+                OutlinedTextField(
+                    value = family,
+                    onValueChange = {},
+                    readOnly = true,
+                    singleLine = true,
+                    label = { Text(stringResource(R.string.dashboard_custom_ble_family)) },
+                    trailingIcon = {
+                        androidx.compose.material3.ExposedDropdownMenuDefaults.TrailingIcon(
+                            expanded = familyExpanded
+                        )
+                    },
+                    modifier = Modifier.menuAnchor().fillMaxWidth()
                 )
-                Row(
-                    modifier = Modifier.horizontalScroll(androidx.compose.foundation.rememberScrollState()),
-                    horizontalArrangement = Arrangement.spacedBy(6.dp)
+                ExposedDropdownMenu(
+                    expanded = familyExpanded,
+                    onDismissRequest = { familyExpanded = false }
                 ) {
                     families.forEach { f ->
-                        androidx.compose.material3.FilterChip(
-                            selected = family == f,
-                            onClick = { family = f; persist() },
-                            label = { Text(f) }
+                        androidx.compose.material3.DropdownMenuItem(
+                            text = { Text(f) },
+                            onClick = {
+                                family = f
+                                familyExpanded = false
+                                persist()
+                            }
                         )
                     }
                 }
@@ -3861,12 +3876,9 @@ private fun CustomBleSheet(
                 label = { Text(stringResource(R.string.dashboard_custom_ble_frames)) },
                 placeholder = { Text("53 65 74 4c 69 67 68 74 4f 4e") },
                 isError = framesError,
-                supportingText = {
-                    Text(
-                        if (framesError) stringResource(R.string.dashboard_custom_ble_frames_error)
-                        else stringResource(R.string.dashboard_custom_ble_frames_hint)
-                    )
-                },
+                supportingText = if (framesError) {
+                    { Text(stringResource(R.string.dashboard_custom_ble_frames_error)) }
+                } else null,
                 minLines = 2,
                 modifier = Modifier.fillMaxWidth()
             )

--- a/app/src/main/java/com/eried/eucplanet/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/eried/eucplanet/ui/settings/SettingsScreen.kt
@@ -1357,6 +1357,7 @@ private fun ActionDragPreview(
     // accent-tinted folder icon so the floating preview reads as "you're
     // moving a group" rather than a plain action.
     val isGroup = isActionGroupKey(key) || key == ACTION_GROUP_TEMPLATE_KEY
+    val isBle = isCustomBleKey(key) || key == CUSTOM_BLE_TEMPLATE_KEY
     val groupIconKey = if (isGroup) {
         if (key == ACTION_GROUP_TEMPLATE_KEY) GROUP_DEFAULT_ICON
         else viewModel.getActionGroup(settings, key)?.icon ?: GROUP_DEFAULT_ICON
@@ -1366,10 +1367,31 @@ private fun ActionDragPreview(
         else viewModel.getActionGroup(settings, key)?.name?.ifBlank { null }
             ?: stringResource(R.string.dashboard_group_default_name)
     } else null
-    val icon = if (isGroup) groupIconFor(groupIconKey!!) else dashboardActionIcon(key)
-    val label = if (isGroup) groupLabel!! else actionChipLabel(key)
-    val tint = if (isGroup) MaterialTheme.colorScheme.primary
-        else MaterialTheme.colorScheme.onSurfaceVariant
+    val bleIconKey = if (isBle) {
+        if (key == CUSTOM_BLE_TEMPLATE_KEY) CUSTOM_BLE_DEFAULT_ICON
+        else viewModel.getCustomBle(settings, key)?.iconKey?.ifBlank { CUSTOM_BLE_DEFAULT_ICON }
+            ?: CUSTOM_BLE_DEFAULT_ICON
+    } else null
+    val bleLabel = if (isBle) {
+        if (key == CUSTOM_BLE_TEMPLATE_KEY) stringResource(R.string.dashboard_custom_ble_template)
+        else viewModel.getCustomBle(settings, key)?.label?.ifBlank { null }
+            ?: stringResource(R.string.dashboard_custom_ble_default_name)
+    } else null
+    val icon = when {
+        isGroup -> groupIconFor(groupIconKey!!)
+        isBle -> groupIconFor(bleIconKey!!)
+        else -> dashboardActionIcon(key)
+    }
+    val label = when {
+        isGroup -> groupLabel!!
+        isBle -> bleLabel!!
+        else -> actionChipLabel(key)
+    }
+    val tint = when {
+        isGroup -> MaterialTheme.colorScheme.primary
+        isBle -> MaterialTheme.colorScheme.tertiary
+        else -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
     val surfaceColor = MaterialTheme.colorScheme.surfaceVariant
     val outlineColor = MaterialTheme.colorScheme.outlineVariant
     Box(
@@ -3807,8 +3829,14 @@ private fun CustomBleSheet(
     val families = listOf("veteran", "kingsong", "begode", "inmotion_v2", "inmotion_v1", "ninebot")
 
     fun persist() {
-        if (parsedFrames != null) lastValid.value = parsedFrames
-        viewModel.updateCustomBle(id, label, icon, family, parsedFrames ?: lastValid.value)
+        // Re-parse the CURRENT text here. `parsedFrames` is a composition-scoped
+        // val captured from the previous composition, so using it persisted the
+        // frames a keystroke behind — a hex that only becomes valid on the last
+        // character never saved, so the field looked empty on reopen (you were
+        // seeing the placeholder, which happens to be the low-beam hex).
+        val parsed = com.eried.eucplanet.data.model.CustomBleCommand.parseFrames(framesText)
+        if (parsed != null) lastValid.value = parsed
+        viewModel.updateCustomBle(id, label, icon, family, parsed ?: lastValid.value)
     }
 
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {

--- a/app/src/main/java/com/eried/eucplanet/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/eried/eucplanet/ui/settings/SettingsScreen.kt
@@ -1151,17 +1151,22 @@ private fun DashboardLayoutTab(
             activeCount = actionActiveCount,
             columns = actionColumnsEffective,
             groupOf = { id -> viewModel.getActionGroup(settings, id) },
+            customBleOf = { id -> viewModel.getCustomBle(settings, id) },
             onSwapInto = { key, index ->
                 // Catalog model — see metric grid for explanation.
                 when {
                     key == ACTION_GROUP_TEMPLATE_KEY -> viewModel.createActionGroupAt(index)
+                    key == CUSTOM_BLE_TEMPLATE_KEY -> viewModel.createCustomBleAt(index)
                     dragController.sourceFromGrid -> viewModel.moveDashboardActionToIndex(key, index)
                     else -> viewModel.setDashboardActionAtIndex(key, index)
                 }
             },
             onTapTile = { key, slotIndex ->
-                editing = if (isActionGroupKey(key)) DashboardEditTarget.Group(key, slotIndex)
-                else DashboardEditTarget.Action(key, slotIndex)
+                editing = when {
+                    isActionGroupKey(key) -> DashboardEditTarget.Group(key, slotIndex)
+                    isCustomBleKey(key) -> DashboardEditTarget.CustomBle(key, slotIndex)
+                    else -> DashboardEditTarget.Action(key, slotIndex)
+                }
             },
             controller = dragController
         )
@@ -1177,6 +1182,7 @@ private fun DashboardLayoutTab(
                 catalogKeys = viewModel.knownDashboardActions,
                 onTap = { _ -> showPoolTapToast() },
                 onDeleteGroup = { id -> viewModel.deleteActionGroup(id) },
+                onDeleteCustomBle = { id -> viewModel.deleteCustomBle(id) },
                 controller = dragController
             )
         }
@@ -1203,12 +1209,15 @@ private fun DashboardLayoutTab(
         // happens to occupy the slot AND wiping the natural key's stats
         // so the restored metric shows its fresh out-of-box appearance.
         val onResetSlot: () -> Unit = {
-            val isActionTarget = target is DashboardEditTarget.Action ||
-                target is DashboardEditTarget.Group
-            if (isActionTarget) {
-                viewModel.resetDashboardActionAtIndex(target.slotIndex)
-            } else {
-                viewModel.resetDashboardMetricAtIndex(target.slotIndex)
+            when {
+                // A custom BLE command has no "shipped default" — Reset means
+                // delete the command and clear the slot.
+                target is DashboardEditTarget.CustomBle ->
+                    viewModel.deleteCustomBle(target.key)
+                target is DashboardEditTarget.Action || target is DashboardEditTarget.Group ->
+                    viewModel.resetDashboardActionAtIndex(target.slotIndex)
+                else ->
+                    viewModel.resetDashboardMetricAtIndex(target.slotIndex)
             }
             editing = null
         }
@@ -1221,6 +1230,13 @@ private fun DashboardLayoutTab(
                 onReset = onResetSlot
             )
             is DashboardEditTarget.Group -> ActionGroupSheet(
+                id = target.key,
+                settings = settings,
+                viewModel = viewModel,
+                onDismiss = { editing = null },
+                onReset = onResetSlot
+            )
+            is DashboardEditTarget.CustomBle -> CustomBleSheet(
                 id = target.key,
                 settings = settings,
                 viewModel = viewModel,
@@ -1402,6 +1418,8 @@ private sealed interface DashboardEditTarget {
     data class Group(override val key: String, override val slotIndex: Int) : DashboardEditTarget
     /** Custom tile instance — `key` is the tile ID like `C:abc123`. */
     data class CustomTile(override val key: String, override val slotIndex: Int) : DashboardEditTarget
+    /** Custom BLE command instance — `key` is the command ID like `B:abc123`. */
+    data class CustomBle(override val key: String, override val slotIndex: Int) : DashboardEditTarget
 }
 
 private const val DASHBOARD_DRAG_METRIC_LABEL = "eucplanet/dashMetric"
@@ -2506,6 +2524,7 @@ private fun ActionMiniGrid(
     activeCount: Int,
     columns: Int,
     groupOf: (String) -> ActionGroup?,
+    customBleOf: (String) -> com.eried.eucplanet.data.model.CustomBleCommand?,
     onSwapInto: (String, Int) -> Unit,
     onTapTile: (String, Int) -> Unit,
     controller: DashboardDragController
@@ -2543,6 +2562,17 @@ private fun ActionMiniGrid(
                                         ActionGroupTile(
                                             id = key,
                                             group = group,
+                                            slotIndex = slotIndex,
+                                            modifier = tileMod,
+                                            onSwapInto = onSwapInto,
+                                            onTap = { onTapTile(key, slotIndex) },
+                                            controller = controller
+                                        )
+                                    }
+                                    isCustomBleKey(key) -> {
+                                        CustomBleTile(
+                                            id = key,
+                                            command = customBleOf(key),
                                             slotIndex = slotIndex,
                                             modifier = tileMod,
                                             onSwapInto = onSwapInto,
@@ -2822,6 +2852,83 @@ private fun ActionGroupTile(
 }
 
 /**
+ * Grid tile for a custom BLE command (`B:<uuid>`). Renders the rider's chosen
+ * icon + label, tinted tertiary so it reads as "a custom command" distinct from
+ * plain actions and groups. Tap opens [CustomBleSheet]; drag/drop mirror
+ * [ActionGroupTile].
+ */
+@Composable
+private fun CustomBleTile(
+    id: String,
+    command: com.eried.eucplanet.data.model.CustomBleCommand?,
+    slotIndex: Int,
+    modifier: Modifier,
+    onSwapInto: (String, Int) -> Unit,
+    onTap: () -> Unit,
+    controller: DashboardDragController
+) {
+    val icon = groupIconFor(command?.iconKey?.ifBlank { CUSTOM_BLE_DEFAULT_ICON } ?: CUSTOM_BLE_DEFAULT_ICON)
+    val label = command?.label?.ifBlank { null }
+        ?: stringResource(R.string.dashboard_custom_ble_default_name)
+    val surfaceColor = MaterialTheme.colorScheme.surfaceVariant
+    val outlineColor = MaterialTheme.colorScheme.outlineVariant
+    val accent = MaterialTheme.colorScheme.tertiary
+    val isBeingDragged = controller.draggingKey == id
+    val isDropTarget = controller.isDragging &&
+        controller.draggingKey != id &&
+        controller.hoveredTarget?.slotIndex == slotIndex &&
+        controller.sourceKind == DragSourceKind.ACTION
+    val borderColor by androidx.compose.animation.animateColorAsState(
+        targetValue = if (isDropTarget) accent else outlineColor,
+        label = "ble-tile-border"
+    )
+    val borderWidth by androidx.compose.animation.core.animateDpAsState(
+        targetValue = if (isDropTarget) 2.dp else 1.dp,
+        label = "ble-tile-border-w"
+    )
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(10.dp))
+            .background(surfaceColor)
+            .border(borderWidth, borderColor, RoundedCornerShape(10.dp))
+            .clickable(onClick = onTap)
+            .dashboardDragSource(
+                key = id,
+                value = "",
+                sourceKind = DragSourceKind.ACTION,
+                controller = controller,
+                fromGrid = true
+            )
+            .dashboardDropTarget(
+                key = "action-slot-$slotIndex",
+                kind = DropKind.ACTION_GRID_SLOT,
+                slotIndex = slotIndex,
+                controller = controller,
+                onDrop = { sourceKey -> onSwapInto(sourceKey, slotIndex) }
+            )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(start = 4.dp, end = 4.dp, top = 21.dp)
+                .alpha(if (isBeingDragged) 0f else 1f),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(icon, contentDescription = null, modifier = Modifier.size(26.dp), tint = accent)
+            Spacer(Modifier.height(4.dp))
+            Text(
+                label,
+                fontSize = 11.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+/**
  * Action pool = catalog. Renders the group template followed by every key
  * in [catalogKeys] sorted alphabetically by display label. Action groups
  * are dynamic instances and only live in the grid — pool drops only handle
@@ -2834,6 +2941,7 @@ private fun ActionPool(
     catalogKeys: List<String>,
     onTap: (String) -> Unit,
     onDeleteGroup: (String) -> Unit,
+    onDeleteCustomBle: (String) -> Unit,
     controller: DashboardDragController
 ) {
     val labeled = catalogKeys.map { it to actionChipLabel(it) }
@@ -2864,14 +2972,18 @@ private fun ActionPool(
                 kind = DropKind.ACTION_POOL_TRASH,
                 controller = controller,
                 onDrop = { sourceKey ->
-                    // Only grid-sourced groups get deleted. Static actions
-                    // can't be removed from the catalog; pool→pool drags
-                    // are no-ops by the same rule.
+                    // Only grid-sourced dynamic instances get deleted. Static
+                    // actions can't be removed from the catalog; pool→pool
+                    // drags are no-ops by the same rule.
                     if (controller.sourceFromGrid && isActionGroupKey(sourceKey)) {
                         onDeleteGroup(sourceKey)
+                    } else if (controller.sourceFromGrid && isCustomBleKey(sourceKey)) {
+                        onDeleteCustomBle(sourceKey)
                     }
                 },
-                acceptsSourceKey = { sourceKey -> isActionGroupKey(sourceKey) },
+                acceptsSourceKey = { sourceKey ->
+                    isActionGroupKey(sourceKey) || isCustomBleKey(sourceKey)
+                },
                 overrideExpectedSizePx = poolPillSizePx
             )
             .verticalScroll(rememberScrollState())
@@ -2886,6 +2998,7 @@ private fun ActionPool(
             // group instance; the template stays here because we render it
             // unconditionally rather than from the order list.
             ActionGroupTemplatePill(controller = controller)
+            CustomBleTemplatePill(controller = controller)
             sorted.forEach { key ->
                 ActionPoolPill(key = key, onTap = onTap, controller = controller)
             }
@@ -2952,6 +3065,74 @@ private fun ActionGroupTemplatePill(
             Spacer(Modifier.height(2.dp))
             Text(
                 stringResource(R.string.dashboard_group_template_label),
+                fontSize = 10.sp,
+                color = labelColor,
+                fontWeight = FontWeight.Medium,
+                letterSpacing = 0.5.sp,
+                maxLines = 1
+            )
+        }
+    }
+}
+
+/**
+ * Pool template for a custom BLE command. Mirrors [ActionGroupTemplatePill]:
+ * a dashed "+ BLE" pill the rider drags onto a grid slot to spawn a new
+ * `B:<uuid>` command (routed to createCustomBleAt) and open its editor.
+ */
+@Composable
+private fun CustomBleTemplatePill(
+    controller: DashboardDragController
+) {
+    val outlineColor = MaterialTheme.colorScheme.tertiary.copy(alpha = 0.6f)
+    val labelColor = MaterialTheme.colorScheme.tertiary
+    val density = LocalDensity.current
+    val dashSpec = remember(density) {
+        androidx.compose.ui.graphics.drawscope.Stroke(
+            width = with(density) { 1.5.dp.toPx() },
+            pathEffect = androidx.compose.ui.graphics.PathEffect.dashPathEffect(
+                floatArrayOf(with(density) { 4.dp.toPx() }, with(density) { 3.dp.toPx() })
+            )
+        )
+    }
+    val cornerRadiusPx = with(density) { 10.dp.toPx() }
+    val isBeingDragged = controller.draggingKey == CUSTOM_BLE_TEMPLATE_KEY
+    Box(
+        modifier = Modifier
+            .width(102.dp)
+            .height(66.dp)
+            .drawBehind {
+                drawRoundRect(
+                    color = outlineColor,
+                    cornerRadius = androidx.compose.ui.geometry.CornerRadius(cornerRadiusPx),
+                    style = dashSpec
+                )
+            }
+            .dashboardDragSource(
+                key = CUSTOM_BLE_TEMPLATE_KEY,
+                value = "",
+                sourceKind = DragSourceKind.ACTION,
+                controller = controller,
+                fromGrid = false
+            )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 6.dp, vertical = 6.dp)
+                .alpha(if (isBeingDragged) 0.4f else 1f),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Bolt,
+                contentDescription = null,
+                tint = labelColor,
+                modifier = Modifier.size(22.dp)
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                stringResource(R.string.dashboard_custom_ble_template),
                 fontSize = 10.sp,
                 color = labelColor,
                 fontWeight = FontWeight.Medium,
@@ -3142,7 +3323,8 @@ private fun DashboardSlotSheet(
                 // keeping them for `when` exhaustiveness.
                 is DashboardEditTarget.Composite,
                 is DashboardEditTarget.Group,
-                is DashboardEditTarget.CustomTile -> Unit
+                is DashboardEditTarget.CustomTile,
+                is DashboardEditTarget.CustomBle -> Unit
             }
             SlotSheetFooter(onReset, onDismiss)
             Spacer(Modifier.height(8.dp))
@@ -3586,6 +3768,108 @@ private fun ActionGroupSheet(
                     }
                 }
             }
+
+            SlotSheetFooter(onReset, onDismiss)
+            Spacer(Modifier.height(8.dp))
+        }
+    }
+}
+
+/**
+ * Editor for a custom BLE command (`B:<uuid>`). Label + icon + target family +
+ * the raw frames (one hex frame per line). Closing commits; Reset deletes the
+ * command. Mirrors [ActionGroupSheet]; frames are validated live and only
+ * persisted when they parse.
+ */
+@OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+@Composable
+private fun CustomBleSheet(
+    id: String,
+    settings: com.eried.eucplanet.data.model.AppSettings,
+    viewModel: SettingsViewModel,
+    onDismiss: () -> Unit,
+    onReset: () -> Unit
+) {
+    val cmd = viewModel.getCustomBle(settings, id)
+        ?: com.eried.eucplanet.data.model.CustomBleCommand(
+            id, "", CUSTOM_BLE_DEFAULT_ICON, "veteran", emptyList()
+        )
+    val sheetState = rememberModalBottomSheetState()
+    var label by remember(id) { mutableStateOf(cmd.label) }
+    var icon by remember(id) { mutableStateOf(cmd.iconKey) }
+    var family by remember(id) { mutableStateOf(cmd.family.ifBlank { "veteran" }) }
+    var framesText by remember(id) {
+        mutableStateOf(com.eried.eucplanet.data.model.CustomBleCommand.framesToText(cmd.frames))
+    }
+    val lastValid = remember(id) { androidx.compose.runtime.mutableStateOf(cmd.frames) }
+    val parsedFrames = com.eried.eucplanet.data.model.CustomBleCommand.parseFrames(framesText)
+    val framesError = parsedFrames == null && framesText.isNotBlank()
+    val families = listOf("veteran", "kingsong", "begode", "inmotion_v2", "inmotion_v1", "ninebot")
+
+    fun persist() {
+        if (parsedFrames != null) lastValid.value = parsedFrames
+        viewModel.updateCustomBle(id, label, icon, family, parsedFrames ?: lastValid.value)
+    }
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Box(modifier = Modifier.padding(top = 8.dp), contentAlignment = Alignment.Center) {
+                    GroupIconButton(currentKey = icon, onSelect = { icon = it; persist() })
+                }
+                OutlinedTextField(
+                    value = label,
+                    onValueChange = { label = it; persist() },
+                    singleLine = true,
+                    label = { Text(stringResource(R.string.dashboard_custom_ble_label)) },
+                    modifier = Modifier.weight(1f)
+                )
+            }
+
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(
+                    stringResource(R.string.dashboard_custom_ble_family),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Row(
+                    modifier = Modifier.horizontalScroll(androidx.compose.foundation.rememberScrollState()),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    families.forEach { f ->
+                        androidx.compose.material3.FilterChip(
+                            selected = family == f,
+                            onClick = { family = f; persist() },
+                            label = { Text(f) }
+                        )
+                    }
+                }
+            }
+
+            OutlinedTextField(
+                value = framesText,
+                onValueChange = { framesText = it; persist() },
+                label = { Text(stringResource(R.string.dashboard_custom_ble_frames)) },
+                placeholder = { Text("53 65 74 4c 69 67 68 74 4f 4e") },
+                isError = framesError,
+                supportingText = {
+                    Text(
+                        if (framesError) stringResource(R.string.dashboard_custom_ble_frames_error)
+                        else stringResource(R.string.dashboard_custom_ble_frames_hint)
+                    )
+                },
+                minLines = 2,
+                modifier = Modifier.fillMaxWidth()
+            )
 
             SlotSheetFooter(onReset, onDismiss)
             Spacer(Modifier.height(8.dp))

--- a/app/src/main/java/com/eried/eucplanet/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/eried/eucplanet/ui/settings/SettingsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import android.location.Location
 import com.eried.eucplanet.ble.ConnectionState
 import com.eried.eucplanet.data.model.AppSettings
+import com.eried.eucplanet.data.model.CustomBleCommand
 import com.eried.eucplanet.data.model.PairedSurface
 import com.eried.eucplanet.data.repository.SettingsRepository
 import com.eried.eucplanet.data.repository.TripRepository
@@ -874,7 +875,7 @@ class SettingsViewModel @Inject constructor(
             listCompositeMetrics(s).keys + listCustomTiles(s).keys
         )
     fun dashboardActionOrder(s: AppSettings): List<String> =
-        sanitize(s.dashboardActionOrder, knownDashboardActions, listActionGroups(s).keys)
+        sanitize(s.dashboardActionOrder, knownDashboardActions, listActionGroups(s).keys + listCustomBle(s).keys)
 
     // --- Composite metrics (multi-cell tiles) -----------------------------
     //
@@ -1039,7 +1040,7 @@ class SettingsViewModel @Inject constructor(
             val order = sanitize(
                 current.dashboardActionOrder,
                 knownDashboardActions,
-                root.keys().asSequence().toSet()
+                root.keys().asSequence().toSet() + listCustomBle(current).keys
             ).toMutableList()
             val safeIdx = insertAtIndex.coerceIn(0, order.size)
             if (safeIdx < order.size) {
@@ -1088,6 +1089,84 @@ class SettingsViewModel @Inject constructor(
                     dashboardActionGroups = root.toString(),
                     dashboardActionOrder = order
                 )
+            )
+        }
+    }
+
+    // --- Custom BLE commands (rider-authored raw frames, family-scoped) ----
+
+    fun listCustomBle(s: AppSettings): Map<String, CustomBleCommand> =
+        CustomBleCommand.parseAll(s.dashboardCustomBle)
+
+    fun getCustomBle(s: AppSettings, id: String): CustomBleCommand? = listCustomBle(s)[id]
+
+    fun createCustomBleAt(insertAtIndex: Int): String {
+        val newId = CustomBleCommand.newId(java.util.UUID.randomUUID().toString().take(8))
+        viewModelScope.launch {
+            val current = settingsRepository.get()
+            val root = parseSlotStatsRoot(current.dashboardCustomBle)
+            root.put(
+                newId,
+                org.json.JSONObject()
+                    .put("label", "")
+                    .put("icon", CUSTOM_BLE_DEFAULT_ICON)
+                    .put("family", "veteran")
+                    .put("frames", org.json.JSONArray(emptyList<String>()))
+            )
+            val order = sanitize(
+                current.dashboardActionOrder,
+                knownDashboardActions,
+                listActionGroups(current).keys + root.keys().asSequence().toSet()
+            ).toMutableList()
+            val safeIdx = insertAtIndex.coerceIn(0, order.size)
+            if (safeIdx < order.size) {
+                val displaced = order.removeAt(safeIdx)
+                order.add(safeIdx, newId)
+                order.add(displaced)
+            } else {
+                order.add(newId)
+            }
+            settingsRepository.update(
+                current.copy(
+                    dashboardCustomBle = root.toString(),
+                    dashboardActionOrder = order.joinToString(",")
+                )
+            )
+        }
+        return newId
+    }
+
+    fun updateCustomBle(
+        id: String,
+        label: String,
+        icon: String,
+        family: String,
+        frames: List<ByteArray>
+    ) {
+        viewModelScope.launch {
+            val current = settingsRepository.get()
+            val root = parseSlotStatsRoot(current.dashboardCustomBle)
+            val node = root.optJSONObject(id) ?: org.json.JSONObject()
+            node.put("label", label)
+            node.put("icon", icon.ifEmpty { CUSTOM_BLE_DEFAULT_ICON })
+            node.put("family", family)
+            node.put("frames", org.json.JSONArray(frames.map { CustomBleCommand.bytesToHex(it) }))
+            root.put(id, node)
+            settingsRepository.update(current.copy(dashboardCustomBle = root.toString()))
+        }
+    }
+
+    fun deleteCustomBle(id: String) {
+        viewModelScope.launch {
+            val current = settingsRepository.get()
+            val root = parseSlotStatsRoot(current.dashboardCustomBle)
+            root.remove(id)
+            val order = current.dashboardActionOrder
+                .split(",").map { it.trim() }
+                .filter { it.isNotEmpty() && it != id }
+                .joinToString(",")
+            settingsRepository.update(
+                current.copy(dashboardCustomBle = root.toString(), dashboardActionOrder = order)
             )
         }
     }
@@ -1287,7 +1366,7 @@ class SettingsViewModel @Inject constructor(
             val items = sanitize(
                 current.dashboardActionOrder,
                 knownDashboardActions,
-                listActionGroups(current).keys
+                listActionGroups(current).keys + listCustomBle(current).keys
             ).toMutableList()
             if (slotIndex !in 0 until ACTIVE_DASHBOARD_TILE_COUNT) return@launch
             if (slotIndex !in items.indices) return@launch
@@ -1295,7 +1374,7 @@ class SettingsViewModel @Inject constructor(
             if (displaced == key) return@launch
 
             items[slotIndex] = key
-            if (isActionGroupKey(displaced)) {
+            if (isActionGroupKey(displaced) || isCustomBleKey(displaced)) {
                 items.removeAll { it == displaced }
             }
 
@@ -1304,10 +1383,16 @@ class SettingsViewModel @Inject constructor(
                     .also { it.remove(displaced) }.toString()
             else current.dashboardActionGroups
 
+            val newBle = if (isCustomBleKey(displaced))
+                parseSlotStatsRoot(current.dashboardCustomBle)
+                    .also { it.remove(displaced) }.toString()
+            else current.dashboardCustomBle
+
             settingsRepository.update(
                 current.copy(
                     dashboardActionOrder = items.joinToString(","),
-                    dashboardActionGroups = newGroups
+                    dashboardActionGroups = newGroups,
+                    dashboardCustomBle = newBle
                 )
             )
         }
@@ -1401,7 +1486,7 @@ class SettingsViewModel @Inject constructor(
             val items = sanitize(
                 current.dashboardActionOrder,
                 knownDashboardActions,
-                listActionGroups(current).keys
+                listActionGroups(current).keys + listCustomBle(current).keys
             ).toMutableList()
             val fromIndex = items.indexOf(key)
             if (fromIndex < 0 || toIndex !in items.indices) return@launch
@@ -1557,7 +1642,7 @@ class SettingsViewModel @Inject constructor(
             val items = sanitize(
                 current.dashboardActionOrder,
                 knownDashboardActions,
-                listActionGroups(current).keys
+                listActionGroups(current).keys + listCustomBle(current).keys
             ).toMutableList()
             val naturalKey = knownDashboardActions.getOrNull(slotIndex) ?: return@launch
             if (slotIndex !in items.indices) return@launch
@@ -1841,6 +1926,10 @@ const val ACTION_GROUP_PREFIX = "G:"
 const val COMPOSITE_TEMPLATE_KEY = "+M"
 /** Pool template key for the "+ Group" action-group source. */
 const val ACTION_GROUP_TEMPLATE_KEY = "+G"
+/** Pool template key for the "+ BLE" custom-command source. */
+const val CUSTOM_BLE_TEMPLATE_KEY = "+B"
+/** Default icon key for a freshly-created custom BLE command. */
+const val CUSTOM_BLE_DEFAULT_ICON = "BOLT"
 /**
  * Prefix marking a composite cell value as rider-typed text rather than a
  * metric key. The string after the prefix is the literal text the cell
@@ -1879,6 +1968,8 @@ const val CUSTOM_TILE_TEMPLATE_KEY = "+C"
 
 fun isCompositeMetricKey(key: String): Boolean = key.startsWith(COMPOSITE_METRIC_PREFIX)
 fun isActionGroupKey(key: String): Boolean = key.startsWith(ACTION_GROUP_PREFIX)
+fun isCustomBleKey(key: String): Boolean =
+    key.startsWith(com.eried.eucplanet.data.model.CustomBleCommand.ID_PREFIX)
 fun isCustomTileKey(key: String): Boolean = key.startsWith(CUSTOM_TILE_PREFIX)
 fun isTextCell(key: String): Boolean = key.startsWith(COMPOSITE_TEXT_PREFIX) || key == "EMPTY"
 fun textCellContent(key: String): String = when {

--- a/app/src/main/java/com/eried/eucplanet/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/eried/eucplanet/ui/settings/SettingsViewModel.kt
@@ -1420,62 +1420,16 @@ class SettingsViewModel @Inject constructor(
             if (fromIndex < 0 || toIndex !in items.indices) return@launch
             if (fromIndex == toIndex) return@launch
 
-            // Move semantics (per rider feedback): drop = put `key` at toIndex
-            // and leave fromIndex EMPTY. The previously-occupant of toIndex
-            // is discarded entirely — composite / custom-tile definitions
-            // for the displaced tile are deleted alongside its order entry
-            // since they only live on the active grid (the pool catalog is
-            // the source of truth for static metrics, so they re-appear in
-            // the pool via sanitize()).
-            val activeCount = ACTIVE_DASHBOARD_TILE_COUNT
+            // Big-tile-to-big-tile drag = genuine A<->B swap: the dragged tile
+            // and the tile it lands on exchange positions. Nothing is created,
+            // deleted, or left empty, so composite / custom-tile instances are
+            // preserved. (Pool->grid drops go through setDashboardMetricAtIndex.)
             val displaced = items[toIndex]
             items[toIndex] = key
-            // Only top-level grid slots get an EMPTY sentinel — pool-area
-            // sources are catalog entries that sanitize() re-adds anyway.
-            if (fromIndex < activeCount) {
-                items[fromIndex] = EMPTY_SLOT_KEY
-            } else {
-                items.removeAt(fromIndex)
-            }
-
-            // Drop the displaced dynamic instance from any remaining order
-            // slot (it was just overwritten at toIndex but may still appear
-            // elsewhere in the list as a duplicate) AND from its definitions.
-            val displacedIsComposite = isCompositeMetricKey(displaced)
-            val displacedIsCustomTile = isCustomTileKey(displaced)
-            if (displacedIsComposite || displacedIsCustomTile) {
-                items.removeAll { it == displaced }
-            }
-
-            // Same orphan cleanup as before: dynamic instances that ended up
-            // past the active region are deleted (no orphan composites in
-            // Available metrics).
-            val orphanedComposites = items.withIndex()
-                .filter { (idx, k) -> idx >= activeCount && isCompositeMetricKey(k) }
-                .map { it.value }
-            val orphanedCustomTiles = items.withIndex()
-                .filter { (idx, k) -> idx >= activeCount && isCustomTileKey(k) }
-                .map { it.value }
-            val toDelete = (orphanedComposites + orphanedCustomTiles +
-                (if (displacedIsComposite || displacedIsCustomTile) listOf(displaced) else emptyList())
-            ).toSet()
-            val cleanedItems = items.filter { it !in (toDelete - setOf(EMPTY_SLOT_KEY)) }
-
-            val compositesRoot = parseSlotStatsRoot(current.dashboardCompositeMetrics)
-            (orphanedComposites + if (displacedIsComposite) listOf(displaced) else emptyList())
-                .toSet()
-                .forEach { compositesRoot.remove(it) }
-            val tilesRoot = parseSlotStatsRoot(current.dashboardCustomTiles)
-            (orphanedCustomTiles + if (displacedIsCustomTile) listOf(displaced) else emptyList())
-                .toSet()
-                .forEach { tilesRoot.remove(it) }
+            items[fromIndex] = displaced
 
             settingsRepository.update(
-                current.copy(
-                    dashboardMetricOrder = cleanedItems.joinToString(","),
-                    dashboardCompositeMetrics = compositesRoot.toString(),
-                    dashboardCustomTiles = tilesRoot.toString()
-                )
+                current.copy(dashboardMetricOrder = items.joinToString(","))
             )
         }
     }
@@ -1492,42 +1446,17 @@ class SettingsViewModel @Inject constructor(
             if (fromIndex < 0 || toIndex !in items.indices) return@launch
             if (fromIndex == toIndex) return@launch
 
-            // Move semantics matching the metric grid: drop = put `key` at
-            // toIndex and leave fromIndex EMPTY. Displaced action group
-            // instance is deleted entirely.
-            val activeCount = ACTIVE_DASHBOARD_TILE_COUNT
+            // Big-tile-to-big-tile drag = genuine A<->B swap: the dragged tile
+            // and the tile it lands on exchange positions. Nothing is created,
+            // deleted, or left empty, so group / custom-BLE instances are
+            // preserved. (Pool->grid drops go through setDashboardActionAtIndex.)
             val displaced = items[toIndex]
             items[toIndex] = key
-            if (fromIndex < activeCount) {
-                items[fromIndex] = EMPTY_SLOT_KEY
-            } else {
-                items.removeAt(fromIndex)
-            }
-            val displacedIsGroup = isActionGroupKey(displaced)
-            if (displacedIsGroup) {
-                items.removeAll { it == displaced }
-            }
+            items[fromIndex] = displaced
 
-            val orphanedGroups = items.withIndex()
-                .filter { (idx, k) -> idx >= activeCount && isActionGroupKey(k) }
-                .map { it.value }
-            val toDelete = (orphanedGroups +
-                (if (displacedIsGroup) listOf(displaced) else emptyList())
-            ).toSet()
-            val cleaned = items.filter { it !in (toDelete - setOf(EMPTY_SLOT_KEY)) }
-
-            if (toDelete.isEmpty()) {
-                settingsRepository.update(current.copy(dashboardActionOrder = cleaned.joinToString(",")))
-            } else {
-                val groupsRoot = parseSlotStatsRoot(current.dashboardActionGroups)
-                toDelete.forEach { groupsRoot.remove(it) }
-                settingsRepository.update(
-                    current.copy(
-                        dashboardActionOrder = cleaned.joinToString(","),
-                        dashboardActionGroups = groupsRoot.toString()
-                    )
-                )
-            }
+            settingsRepository.update(
+                current.copy(dashboardActionOrder = items.joinToString(","))
+            )
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,6 +122,13 @@
     <string name="dashboard_view_wide">Wide</string>
     <string name="dashboard_composite_template_label">MULTI</string>
     <string name="dashboard_group_template_label">GROUP</string>
+    <string name="dashboard_custom_ble_template">BLE</string>
+    <string name="dashboard_custom_ble_default_name">Custom BLE</string>
+    <string name="dashboard_custom_ble_label">Button label</string>
+    <string name="dashboard_custom_ble_family">Wheel family</string>
+    <string name="dashboard_custom_ble_frames">Frames (hex, one per line)</string>
+    <string name="dashboard_custom_ble_frames_hint">One frame per line. Paste raw bytes, e.g. a btsnoop capture.</string>
+    <string name="dashboard_custom_ble_frames_error">Invalid hex — use byte pairs like 4c 6b 41 70</string>
     <string name="dashboard_composite_layout_row2">2 rows</string>
     <string name="dashboard_composite_layout_col2">2 columns</string>
     <string name="dashboard_composite_layout_col3">3 columns</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -125,9 +125,8 @@
     <string name="dashboard_custom_ble_template">BLE</string>
     <string name="dashboard_custom_ble_default_name">Custom BLE</string>
     <string name="dashboard_custom_ble_label">Button label</string>
-    <string name="dashboard_custom_ble_family">Wheel family</string>
-    <string name="dashboard_custom_ble_frames">Frames (hex, one per line)</string>
-    <string name="dashboard_custom_ble_frames_hint">One frame per line. Paste raw bytes, e.g. a btsnoop capture.</string>
+    <string name="dashboard_custom_ble_family">Wheel family filter</string>
+    <string name="dashboard_custom_ble_frames">Frames (hex)</string>
     <string name="dashboard_custom_ble_frames_error">Invalid hex — use byte pairs like 4c 6b 41 70</string>
     <string name="dashboard_composite_layout_row2">2 rows</string>
     <string name="dashboard_composite_layout_col2">2 columns</string>

--- a/app/src/test/java/com/eried/eucplanet/ble/VeteranHornTest.kt
+++ b/app/src/test/java/com/eried/eucplanet/ble/VeteranHornTest.kt
@@ -1,0 +1,47 @@
+package com.eried.eucplanet.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import java.util.zip.CRC32
+
+/**
+ * Pins the Veteran horn command for current (Lynx-class) LeaperKim firmware.
+ *
+ * Decoded from a btsnoop of the official LeaperKim app sounding the horn on a
+ * Lynx S (mVer 9, May 2026): every press writes an `LkAp` frame immediately
+ * followed by an `LdAp` companion frame. WheelLog (and older EUC Planet builds)
+ * send only the `LkAp` half, which Lynx-class firmware silently ignores, so the
+ * horn never beeps. Both frames are byte-for-byte fixed (no nonce/counter across
+ * the three captured presses). Pure-JVM test; no Android runtime needed.
+ */
+class VeteranHornTest {
+
+    private fun ByteArray.hex() = joinToString(" ") { "%02x".format(it) }
+
+    // Exact bytes observed on the wire, both presses identical.
+    private val LKAP_HORN = "4c 6b 41 70 0e 00 80 80 80 01 ca 87 e6 6f"
+    private val LDAP_HORN = "4c 64 41 70 0e 00 00 80 80 01 f8 67 9f 85"
+
+    @Test
+    fun `veteran horn emits the LkAp frame then the LdAp companion`() {
+        val adapter = VeteranAdapter()
+        assertEquals(LKAP_HORN, adapter.horn().hex())
+        val followup = adapter.hornFollowup()
+        assertNotNull("Veteran must send the LdAp horn companion", followup)
+        assertEquals(LDAP_HORN, followup!!.hex())
+    }
+
+    @Test
+    fun `both horn frames carry a valid big-endian CRC32 trailer`() {
+        for (frame in listOf(VeteranCommands.horn(), VeteranCommands.hornCompanion())) {
+            val body = frame.copyOfRange(0, frame.size - 4)
+            val want = CRC32().apply { update(body) }.value.toInt()
+            val got = ((frame[frame.size - 4].toInt() and 0xff) shl 24) or
+                ((frame[frame.size - 3].toInt() and 0xff) shl 16) or
+                ((frame[frame.size - 2].toInt() and 0xff) shl 8) or
+                (frame[frame.size - 1].toInt() and 0xff)
+            assertEquals("CRC32 mismatch on ${frame.hex()}", want, got)
+        }
+    }
+}

--- a/app/src/test/java/com/eried/eucplanet/ble/VeteranLightTest.kt
+++ b/app/src/test/java/com/eried/eucplanet/ble/VeteranLightTest.kt
@@ -1,0 +1,45 @@
+package com.eried.eucplanet.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+/**
+ * Pins the Veteran headlight commands.
+ *
+ * The in-app light toggle drives the HIGH beam by default: a two-frame
+ * `LkAp` + `LdAp` pair decoded from a LeaperKim-app btsnoop on a Lynx S
+ * (high beam on @cap25.3s, off @cap28.3s). The legacy ASCII `SetLightON/OFF`
+ * (low beam) stays available as a commented fallback in [VeteranAdapter].
+ * Pure-JVM test; no Android runtime needed.
+ */
+class VeteranLightTest {
+
+    private fun ByteArray.hex() = joinToString(" ") { "%02x".format(it) }
+
+    private val HIGHBEAM_ON_LKAP = "4c 6b 41 70 0d 01 80 80 01 57 ed 3b d5"
+    private val HIGHBEAM_ON_LDAP = "4c 64 41 70 0d 01 00 80 01 6f f8 32 f9"
+    private val HIGHBEAM_OFF_LKAP = "4c 6b 41 70 0d 01 80 80 00 20 ea 0b 43"
+    private val HIGHBEAM_OFF_LDAP = "4c 64 41 70 0d 01 00 80 00 18 ff 02 6f"
+
+    @Test
+    fun `high beam on is the captured LkAp + LdAp pair`() {
+        assertEquals(HIGHBEAM_ON_LKAP, VeteranCommands.setHighBeam(true).hex())
+        assertEquals(HIGHBEAM_ON_LDAP, VeteranCommands.setHighBeamCompanion(true).hex())
+    }
+
+    @Test
+    fun `high beam off is the captured LkAp + LdAp pair`() {
+        assertEquals(HIGHBEAM_OFF_LKAP, VeteranCommands.setHighBeam(false).hex())
+        assertEquals(HIGHBEAM_OFF_LDAP, VeteranCommands.setHighBeamCompanion(false).hex())
+    }
+
+    @Test
+    fun `veteran light toggle drives high beam by default, with companion`() {
+        val adapter = VeteranAdapter()
+        assertEquals(HIGHBEAM_ON_LKAP, adapter.setLight(true).hex())
+        val followup = adapter.setLightFollowup(true)
+        assertNotNull("high beam needs the LdAp companion", followup)
+        assertEquals(HIGHBEAM_ON_LDAP, followup!!.hex())
+    }
+}

--- a/app/src/test/java/com/eried/eucplanet/data/model/CustomBleCommandTest.kt
+++ b/app/src/test/java/com/eried/eucplanet/data/model/CustomBleCommandTest.kt
@@ -1,0 +1,115 @@
+package com.eried.eucplanet.data.model
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM tests for the CUSTOM BLE command model — hex parsing and the
+ * multiline frames blob. The JSON round-trip uses org.json (like SettingsJson)
+ * and is exercised by the build, not here. No Android runtime needed.
+ */
+class CustomBleCommandTest {
+
+    @Test
+    fun `parseHexFrame accepts spaces`() {
+        assertArrayEquals(
+            byteArrayOf(0x4c, 0x6b, 0x41, 0x70),
+            CustomBleCommand.parseHexFrame("4c 6b 41 70")
+        )
+    }
+
+    @Test
+    fun `parseHexFrame accepts bare, 0x and separators`() {
+        assertArrayEquals(byteArrayOf(0x4c, 0x6b), CustomBleCommand.parseHexFrame("4c6b"))
+        assertArrayEquals(byteArrayOf(0x4c, 0x6b), CustomBleCommand.parseHexFrame("0x4c, 0x6b"))
+        assertArrayEquals(byteArrayOf(0x53, 0x65), CustomBleCommand.parseHexFrame("53:65"))
+    }
+
+    @Test
+    fun `parseHexFrame rejects odd length`() {
+        assertNull(CustomBleCommand.parseHexFrame("4c6"))
+    }
+
+    @Test
+    fun `parseHexFrame rejects non-hex`() {
+        assertNull(CustomBleCommand.parseHexFrame("zz"))
+        assertNull(CustomBleCommand.parseHexFrame("4c xx"))
+    }
+
+    @Test
+    fun `parseHexFrame blank is null`() {
+        assertNull(CustomBleCommand.parseHexFrame("   "))
+    }
+
+    @Test
+    fun `parseFrames splits non-blank lines`() {
+        val frames = CustomBleCommand.parseFrames("53 65\n\n4c 64 ")!!
+        assertEquals(2, frames.size)
+        assertArrayEquals(byteArrayOf(0x53, 0x65), frames[0])
+        assertArrayEquals(byteArrayOf(0x4c, 0x64), frames[1])
+    }
+
+    @Test
+    fun `parseFrames returns null when any line invalid`() {
+        assertNull(CustomBleCommand.parseFrames("53 65\nzz"))
+    }
+
+    @Test
+    fun `bytesToHex and framesToText`() {
+        assertEquals("4c 6b", CustomBleCommand.bytesToHex(byteArrayOf(0x4c, 0x6b)))
+        assertEquals(
+            "4c 6b\n53 65",
+            CustomBleCommand.framesToText(listOf(byteArrayOf(0x4c, 0x6b), byteArrayOf(0x53, 0x65)))
+        )
+    }
+
+    @Test
+    fun `isCustomBleId recognises the prefix`() {
+        assertTrue(CustomBleCommand.isCustomBleId("B:abc"))
+        assertFalse(CustomBleCommand.isCustomBleId("HORN"))
+    }
+
+    @Test
+    fun `low-beam preset hex equals SetLightON`() {
+        assertArrayEquals(
+            "SetLightON".toByteArray(Charsets.US_ASCII),
+            CustomBleCommand.parseHexFrame("53 65 74 4c 69 67 68 74 4f 4e")
+        )
+    }
+
+    private fun cmd(family: String, frames: List<ByteArray> = listOf(byteArrayOf(0x62))) =
+        CustomBleCommand("B:1", "x", "Campaign", family, frames)
+
+    @Test
+    fun `resolveForDispatch returns command when family matches and connected`() {
+        val c = cmd("veteran")
+        assertEquals(c, CustomBleCommand.resolveForDispatch(mapOf(c.id to c), "B:1", "veteran"))
+    }
+
+    @Test
+    fun `resolveForDispatch is null on wrong family`() {
+        val c = cmd("veteran")
+        assertNull(CustomBleCommand.resolveForDispatch(mapOf(c.id to c), "B:1", "kingsong"))
+    }
+
+    @Test
+    fun `resolveForDispatch is null when disconnected`() {
+        val c = cmd("veteran")
+        assertNull(CustomBleCommand.resolveForDispatch(mapOf(c.id to c), "B:1", null))
+    }
+
+    @Test
+    fun `resolveForDispatch is null when command has no sendable frames`() {
+        val c = cmd("veteran", emptyList())
+        assertNull(CustomBleCommand.resolveForDispatch(mapOf(c.id to c), "B:1", "veteran"))
+    }
+
+    @Test
+    fun `resolveForDispatch is null when key missing`() {
+        assertNull(CustomBleCommand.resolveForDispatch(emptyMap(), "B:1", "veteran"))
+    }
+}

--- a/docs/protocols/veteran.md
+++ b/docs/protocols/veteran.md
@@ -170,7 +170,12 @@ Cell counts per model:
 ## 6. Control commands
 
 Commands are ASCII strings written to the notify/write characteristic, except for
-the v3+ horn which is a 14-byte binary blob. Bytes go out as one BLE write each.
+the horn and the LeaperKim binary settings (section 6.2), which are CRC32-framed
+binary. The horn on Sherman S and newer is a PAIR of 14-byte frames (`LkAp` then
+`LdAp`); the single `LkAp` blob that WheelLog sends is silently ignored by
+Lynx-class firmware (see section 6.2). Bytes go out as one BLE write each; a
+logical frame larger than the ATT MTU is split across writes and the wheel
+reassembles by magic.
 
 ### 6.1 ASCII commands
 
@@ -223,8 +228,9 @@ Known sub-frames, all observed in a single captured session:
 | Angle adjustment | LkAp  | 16        | `01 80 80 80 80 80 <i8>`                 | i8 in tenths of a degree (e.g. `0xDC` = -36 → -3.6°) |
 | Ride mode        | LdAp  | 15        | `01 02 80 80 80 <u8>`                    | u8 ride-mode scalar (observed range 30..100, slider labels match raw value) |
 | PWM%             | LdAp  | 18        | `01 02 80 80 80 80 80 80 <u8>`           | u8 PWM percent (observed 53, 64) |
-| Beep / horn      | LkAp  | 14        | `00 80 80 80 01`                         | n/a — one-shot trigger |
-| Toggle (unknown) | LkAp  | 13        | `01 80 80 <0\|1>`                        | u8 boolean — purpose not yet identified (seen during a transition between connection states) |
+| Horn (frame 1)   | LkAp  | 14        | `00 80 80 80 01`                         | n/a — one-shot trigger; MUST be sent with frame 2 |
+| Horn (frame 2)   | LdAp  | 14        | `00 00 80 80 01`                         | n/a — companion; without it Lynx-class firmware stays silent |
+| High beam on/off | LkAp + LdAp | 13   | `01 80 80 <0\|1>` then `01 00 80 <0\|1>` | u8 boolean, last byte `01`=on / `00`=off. Separate from the ASCII `SetLightON/OFF` low beam. |
 
 Notes:
 
@@ -233,11 +239,20 @@ Notes:
   prefix and payload byte 1 (`0x02` vs `0x80`).
 - Every captured frame validated against `CRC32(magic + length + payload)` big-endian.
   The Java `zlib.CRC32` is byte-identical to what the LeaperKim app emits.
-- A typical write is followed immediately by an `LdAp` echo / ack frame from the app
-  with the same length and a similar payload; we have not yet confirmed whether the
-  echo is a separate write or a fragmented continuation of the same GATT operation.
-  Sending only the first frame appears sufficient — the wheel applies the setting
-  on the next realtime frame's offsets 24/26.
+- Each command is two back-to-back frames in the byte stream: the `LkAp` frame
+  immediately followed by an `LdAp` companion of the same length. They are NOT a
+  fragmented single GATT operation — they are two distinct vendor frames the wheel
+  reassembles by magic (the app streams the ~28-byte pair as 20 + 8 byte ATT writes
+  purely because of the 20-byte MTU).
+  - For the **value settings** (tilt-back, alarm, …) the `LkAp` frame alone is
+    sufficient: the wheel reflects the new value on the next realtime frame
+    (offsets 24/26), so the `LdAp` companion looks like a redundant echo.
+  - The **horn is the exception** — a one-shot with no readback. The wheel only
+    beeps when the `LkAp` frame (`00 80 80 80 01`) is followed by its `LdAp`
+    companion (`00 00 80 80 01`). Sending the `LkAp` blob alone — exactly what
+    WheelLog and pre-fix EUC Planet builds do — reaches the wheel with a valid
+    CRC but produces no sound (verified on a Lynx S btsnoop: four `LkAp`-only
+    writes, zero beeps; the official app sends both frames on every press).
 - We currently surface only tilt-back and alarm in `VeteranCommands`; the other
   decoded frames live there as private builders so the protocol knowledge is
   preserved when we add UI for them.

--- a/docs/superpowers/specs/2026-06-01-custom-ble-action-design.md
+++ b/docs/superpowers/specs/2026-06-01-custom-ble-action-design.md
@@ -1,0 +1,200 @@
+# CUSTOM BLE action — design
+
+Status: **approved (design), pre-implementation**
+Date: 2026-06-01
+Branch: `fix/LK19486-horn` (will likely move to its own branch for implementation)
+
+## 1. Motivation
+
+Advanced users want to send wheel commands EUC Planet doesn't expose yet. The
+trigger case: the in-app light toggle now drives the Veteran **high** beam
+(`LkAp`/`LdAp` pair), so a rider who wants the **low** beam (`SetLightON`) needs
+a way to send arbitrary bytes themselves. Generalize that into a draggable
+**CUSTOM BLE** action: a dashboard button that writes user-defined bytes to the
+connected wheel.
+
+This must expand functionality for SOME wheels without affecting others — a raw
+write goes to whatever is connected, so each custom command is scoped to a wheel
+family and only fires on a match.
+
+## 2. Decisions (locked with the user)
+
+| # | Decision |
+|---|----------|
+| 1 | **Write-only** v1 — tap fires bytes, no response parsing, no state (like HORN). Schema leaves room for a future read. |
+| 2 | **Whole raw frame(s)** — the user pastes complete bytes (e.g. from a btsnoop); sent verbatim. Captured frames already carry a valid CRC, so no CRC code is needed and it works for every family. Optional Veteran "payload + auto-CRC" mode is a future nicety, not v1. |
+| 3 | **Family-scoped** — each command is tagged with a target `familyId` and only appears/fires on a matching wheel. Useless on other wheels is expected and acceptable. |
+| 4 | **Multi-frame** — a command is an ordered list of frames, sent as separate writes (covers Veteran `LkAp`+`LdAp` pairs). |
+| 5 | **Dashboard tiles only** for v1 (the "Actions buttons" section). Flic/volume/watch deferred. |
+
+## 3. Approach
+
+Mirror the existing synthetic-ID tile pattern already used by the customizable
+dashboard, rather than invent a new command library or a dynamic `ActionCatalog`
+layer:
+
+- `dashboardActionOrder` is a CSV of action keys; group tiles already use a
+  synthetic id `G:<uuid>` whose definition lives in `dashboardActionGroups`.
+- Metric tiles use `M:<uuid>` (`dashboardCompositeMetrics`) and `C:<uuid>`
+  (`dashboardCustomTiles`, the `{text,icon,action,url}` custom tiles).
+
+CUSTOM BLE is the action-grid twin of `dashboardCustomTiles`: a new synthetic id
+`B:<uuid>` in `dashboardActionOrder`, with its definition in a sibling JSON
+field. Built-in actions, the dispatch path, and other wheel families stay
+untouched; the feature is purely additive.
+
+## 4. Data model
+
+New field in `data/model/AppSettings.kt`, exact sibling of `dashboardCustomTiles`:
+
+```kotlin
+/**
+ * Custom BLE action definitions as a JSON object keyed by "B:<uuid>". Value:
+ * { "label":"Low beam", "icon":"FlashlightOn", "family":"veteran",
+ *   "frames":["53 65 74 4c 69 67 68 74 4f 4e"] }
+ * - frames: 1+ hex strings, each sent as one BLE write in array order.
+ * - family: target adapter familyId; the command only fires on a match.
+ * B:<uuid> ids appear in [dashboardActionOrder] like G:/group ids.
+ */
+val dashboardCustomBle: String = "{}",
+```
+
+Parsed model (new `data/model/CustomBleCommand.kt`):
+
+```kotlin
+data class CustomBleCommand(
+    val id: String,            // "B:<uuid>"
+    val label: String,
+    val iconKey: String,       // reuse the existing icon-key table (custom tiles / WatchActionMeta)
+    val family: String,        // adapter familyId: "veteran", "kingsong", ...
+    val frames: List<ByteArray> // already-parsed bytes, sent in order
+)
+```
+
+- Serialization lives with the other dashboard JSON in `data/store/SettingsJson.kt`
+  (`put("dashboardCustomBle", ...)` / `optString(...)`), following the existing
+  `dashboardCustomTiles` round-trip exactly.
+- Stored hex is canonical; the editor's ASCII helper converts to hex on save.
+- Read/merge rule matches the others: a `B:` token in the order CSV with no
+  matching JSON entry is dropped; deleting a command removes both the token and
+  the JSON entry.
+
+## 5. Palette + drag
+
+Add a **CUSTOM BLE** template to the actions palette next to the existing
+**+ Group** template (the dashboard layout editor in `ui/settings/SettingsScreen.kt`).
+Dragging it:
+
+1. Generates `B:<uuid>`, defaulting `family` to the connected wheel's `familyId`
+   (fallback: first family / "veteran").
+2. Inserts the id into `dashboardActionOrder` at the drop position.
+3. Opens the per-slot editor for immediate configuration.
+
+## 6. Editor (per-slot bottom sheet)
+
+Reuse the existing action-slot bottom sheet. When the slot id starts with `B:`,
+render a CUSTOM BLE form:
+
+- **Label** (text) — button caption.
+- **Icon** (picker) — from the existing icon-key set.
+- **Target family** (dropdown) — known adapter families; default = connected wheel.
+- **Frames** (multiline) — one frame per line, hex (spaces / `0x` / bare all
+  accepted). Live validation: even hex-digit count, per-line byte count, total
+  frame count. A per-editor **ASCII** toggle converts typed text → hex on commit.
+- Closing the sheet commits (matches the no-Save-button pattern).
+
+Validation feedback:
+- Invalid hex → inline error, command saved but flagged; dispatch no-ops a
+  command with zero valid frames.
+- A frame > 20 bytes shows a soft warning ("may be truncated on this wheel's
+  MTU; split into multiple frames"). The wheel reassembles multi-frame writes by
+  magic, same as the official app's 20+8 split.
+
+## 7. Dispatch (single path)
+
+All action dispatch already funnels through `FlicManager.executeAction(key)`
+(the dashboard delegates via `dispatchActionByName`). Add one branch:
+
+```kotlin
+if (key.startsWith("B:")) {
+    val cmd = customBleCommands(settings)[key] ?: return
+    if (cmd.family != wheelRepository.connectedFamilyId) {
+        // wrong wheel — ignore + brief toast
+        return
+    }
+    wheelRepository.sendCustomBle(cmd.frames)
+    return
+}
+```
+
+- `wheelRepository.connectedFamilyId`: new accessor exposing the active adapter's
+  `familyId` (CompositeWheelAdapter already tracks `active.familyId`); null when
+  disconnected.
+
+## 8. Repository
+
+```kotlin
+fun sendCustomBle(frames: List<ByteArray>) {
+    frames.forEach { if (it.isNotEmpty()) bleManager.writeCommand(it) }
+}
+```
+
+Each frame is one queued write, processed in order by the existing serial write
+queue — the same mechanism the Veteran horn pair uses.
+
+## 9. Gating ("don't mess other wheels")
+
+- A command only fires when `cmd.family == connectedFamilyId`.
+- In the editor / dashboard, a custom command whose family ≠ the connected wheel
+  renders dimmed with a "for <family>" caption; tapping it on the wrong wheel is
+  a no-op with a toast.
+- Raw bytes never reach a wheel they were not authored for. Built-in actions are
+  unaffected.
+
+## 10. Surfaces
+
+v1: dashboard action tiles only. Because dispatch is the shared `FlicManager`
+path, adding Flic/volume/watch later is just exposing `B:` ids to those pools
+behind a future `eyesFreeSafe` flag on the command (custom bytes are not assumed
+eyes-free-safe by default).
+
+## 11. Low-beam example (the concrete deliverable)
+
+Ship a built-in template the user can drop and have working immediately:
+
+- **Veteran low beam (on)** — `family:"veteran"`, `frames:["53 65 74 4c 69 67 68 74 4f 4e"]` (`SetLightON`).
+- **Veteran low beam (off)** — `frames:["53 65 74 4c 69 67 68 74 4f 46 46"]` (`SetLightOFF`).
+
+(Write-only means one button = one fixed command, so low beam ships as an
+on/off pair, matching how the rider thinks about a separate low-beam switch.)
+
+## 12. Testing
+
+JVM unit tests (no Android runtime), matching the existing `ble` test style:
+- `CustomBleCommand` JSON round-trip (parse/serialize, including multi-frame and
+  malformed-hex rejection).
+- Hex parser: spaces / `0x` / bare, odd-digit rejection, ASCII→hex conversion.
+- Dispatch gating: family match fires, mismatch no-ops (logic extracted to a
+  pure function so it's testable without Android).
+- Low-beam preset bytes equal `SetLightON` / `SetLightOFF`.
+
+UI (palette, drag, editor) verified by `assembleDebug` + emulator smoke, per the
+project's standing build gate.
+
+## 13. Out of scope for v1 (reserved, additive later)
+
+- Reading wheel state (would need per-family response parsing/subscription).
+- Veteran "payload + auto-CRC" authoring mode (we already have `buildVendorFrame`).
+- Per-model gating (family is enough for now).
+- Eyes-free surfaces (Flic / volume / watch).
+
+## 14. Affected files
+
+- `data/model/AppSettings.kt` — new `dashboardCustomBle` field.
+- `data/store/SettingsJson.kt` — serialize/deserialize it.
+- `data/model/CustomBleCommand.kt` — new parsed model + JSON helpers + hex parser.
+- `flic/FlicManager.kt` — `B:` dispatch branch.
+- `data/repository/WheelRepository.kt` — `sendCustomBle`, `connectedFamilyId`.
+- `ui/settings/SettingsScreen.kt` — palette template + per-slot editor form.
+- (strings.xml) — labels for the template, editor fields, toasts.
+- tests under `app/src/test/.../ble` (or `.../data`).


### PR DESCRIPTION
Merges the `fix/LK19486-horn` line of work into `next-version`.

## What lands
- **LK19486 horn fix** — two-frame `LkAp`/`LdAp` commands for Veteran (also fixes high beam).
- **CUSTOM BLE action support** — data model, persistence, family-gated dispatch, dashboard editor UI/palette + runtime button.
- **Dashboard editor**
  - True big-tile swap.
  - Grid-tile drag-out to the pool / off-grid is now a **no-op** (snaps back) instead of deleting via a pool trash target. Group / custom-BLE / composite / custom-tile instances are removed only via the slot editor (Reset slot) or by being displaced when another tile is dropped on them — `setDashboard*AtIndex` already deletes those symmetrically.
  - Restored the **"+ Tile"** custom-tile template pill in the metrics pool.
  - Removed the now-unused `ACTION_POOL_TRASH` / `METRIC_POOL_TRASH` drop targets and `onDelete*` pool callbacks.

## Verification
- `:app:compileDebugKotlin` ✅ on the merged tree (HUD changes from next-version + this work built together for the first time).
- `:app:testDebugUnitTest` ✅ (incl. `VeteranHornTest`, `VeteranLightTest`, `CustomBleCommandTest`).
- Installed on emulator-5558, launches cleanly, no logcat exceptions.

Merge was conflict-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)