### PR TITLE
Trip Details: combined-trip battery start→end + rename trips with auto-sync

### DIFF
--- a/app/src/main/java/com/eried/eucplanet/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/eried/eucplanet/data/db/AppDatabase.kt
@@ -16,7 +16,7 @@ import com.eried.eucplanet.data.model.WheelProfile
  */
 @Database(
     entities = [TripRecord::class, AlarmRule::class, WheelProfile::class],
-    version = 55,
+    version = 56,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/app/src/main/java/com/eried/eucplanet/data/db/TripDao.kt
+++ b/app/src/main/java/com/eried/eucplanet/data/db/TripDao.kt
@@ -51,6 +51,17 @@ interface TripDao {
     @Query("UPDATE trips SET wheelMetaJson = :json WHERE id = :id")
     suspend fun updateWheelMeta(id: Long, json: String?)
 
+    /** Set (or clear, with null) the rider's custom trip name. Single-column
+     *  update so it never disturbs upload status or timings. */
+    @Query("UPDATE trips SET customName = :name WHERE id = :id")
+    suspend fun updateCustomName(id: Long, name: String?)
+
+    /** Re-flag a trip for folder upload after its file was edited in place
+     *  (rename / change wheel). The folder worker only walks uploadStatus 1/3,
+     *  so an already-uploaded (2) trip would otherwise never re-sync. */
+    @Query("UPDATE trips SET uploadStatus = 1 WHERE id = :id")
+    suspend fun markPendingFolderUpload(id: Long)
+
     /** Every wheel identity any trip carries. Feeds the trip-tools wheel picker
      *  so a wheel that was only ever imported, never paired, is still offered. */
     @Query("SELECT wheelMetaJson FROM trips WHERE wheelMetaJson IS NOT NULL")

--- a/app/src/main/java/com/eried/eucplanet/data/model/AppSettings.kt
+++ b/app/src/main/java/com/eried/eucplanet/data/model/AppSettings.kt
@@ -246,6 +246,10 @@ data class AppSettings(
     // extra graph keys that were switched ON. Empty = none, the original six
     // charts only.
     val tripExtraCharts: String = "",
+    // Same inverted store for stat tiles that ship OFF (start battery, energy,
+    // consumption): lists the extra tile keys the rider switched ON, so a new
+    // optional tile never appears for everyone on upgrade. Empty = none.
+    val tripExtraTiles: String = "",
 
     // Screen geometry. Compact mode is the tiny dashboard (speedo + one
     // swipeable buttons/metrics area) used on flip cover screens; it reuses

--- a/app/src/main/java/com/eried/eucplanet/data/model/TripRecord.kt
+++ b/app/src/main/java/com/eried/eucplanet/data/model/TripRecord.kt
@@ -20,5 +20,8 @@ data class TripRecord(
     val eucstatsValidation: String? = null,  // "validated" | "flagged"
     val isMockLocation: Boolean = false,     // any fix during recording was mock
     val sampleCount: Int = 0,                // CSV data rows
-    val wheelMetaJson: String? = null        // {brand,model,serial,ble_mac,ble_name,firmware}
+    val wheelMetaJson: String? = null,       // {brand,model,serial,ble_mac,ble_name,firmware}
+    // Rider-set trip name; null = fall back to the formatted date. Also written
+    // into the CSV Extra column as trip.name= so it survives export / Dropbox.
+    val customName: String? = null
 )

--- a/app/src/main/java/com/eried/eucplanet/data/repository/TripDerive.kt
+++ b/app/src/main/java/com/eried/eucplanet/data/repository/TripDerive.kt
@@ -122,6 +122,72 @@ object TripDerive {
     }
 
     /**
+     * Upsert a rider-set trip name into the CSV Extra column as a single
+     * `trip.name=<name>` pair, so a rename survives export and a Dropbox
+     * round-trip with no sidecar file (the same convention eucviewer reads).
+     *
+     * A blank [name] removes the pair (the reader then falls back to the date).
+     * The name is sanitised like any Extra cell (commas / quotes / newlines
+     * collapse to a space) and capped at 60 chars to match the reader.
+     *
+     * Placement: the first existing `trip.name=` cell is rewritten (and any
+     * further duplicates cleared) so the reader, which takes the first hit,
+     * always sees the new value. If none exists, the pair is dropped into the
+     * first row whose Extra cell is empty - the same place wheel.* pairs ride,
+     * a normal telemetry row, never a fabricated one.
+     *
+     * @return 1 if the name was written/updated/removed, 0 if the file has no
+     *   Extra column (a foreign import) or no slot was available.
+     */
+    fun rewriteTripName(source: File, dest: File, name: String): Int {
+        if (!source.exists()) return 0
+        // Collapse commas / quotes / any whitespace run to a single space so the
+        // name can't break CSV framing and reads cleanly. Capped to match reader.
+        val clean = name.replace(Regex("[,\"\\s]+"), " ").trim().take(60)
+        // Pass 1: is there already a trip.name= row to overwrite in place?
+        var hasExisting = false
+        source.bufferedReader().use { reader ->
+            val header = reader.readLine() ?: return 0
+            val idx = header.lowercase().split(",").map { it.trim() }.indexOf("extra")
+            if (idx < 0) return 0
+            while (true) {
+                val line = reader.readLine() ?: break
+                val cell = line.split(",").getOrNull(idx)?.trim().orEmpty()
+                if (cell.startsWith("trip.name=", ignoreCase = true)) { hasExisting = true; break }
+            }
+        }
+        var wrote = 0
+        var placed = false
+        source.bufferedReader().use { reader ->
+            val header = reader.readLine() ?: return 0
+            val idx = header.lowercase().split(",").map { it.trim() }.indexOf("extra")
+            dest.bufferedWriter().use { out ->
+                out.write(header); out.newLine()
+                while (true) {
+                    val line = reader.readLine() ?: break
+                    if (idx < 0) { out.write(line); out.newLine(); continue }
+                    val cells = line.split(",").toMutableList()
+                    val cell = cells.getOrNull(idx)?.trim().orEmpty()
+                    val newCell: String? = when {
+                        cell.startsWith("trip.name=", ignoreCase = true) ->
+                            if (!placed && clean.isNotEmpty()) { placed = true; "trip.name=$clean" }
+                            else "" // clear duplicates, or blank the name entirely
+                        !placed && !hasExisting && clean.isNotEmpty() && cell.isEmpty() &&
+                            idx < cells.size -> { placed = true; "trip.name=$clean" }
+                        else -> null
+                    }
+                    if (newCell == null) { out.write(line); out.newLine(); continue }
+                    cells[idx] = newCell
+                    out.write(cells.joinToString(","))
+                    out.newLine()
+                    wrote = 1
+                }
+            }
+        }
+        return wrote
+    }
+
+    /**
      * Concatenate [sources] into [dest], oldest first, keeping one header.
      *
      * Each source's header is read and discarded rather than assumed identical:

--- a/app/src/main/java/com/eried/eucplanet/data/repository/TripRepository.kt
+++ b/app/src/main/java/com/eried/eucplanet/data/repository/TripRepository.kt
@@ -1127,7 +1127,62 @@ class TripRepository @Inject constructor(
             mac?.let { put("ble_mac", it.replace(":", "").replace("-", "").uppercase()) }
         }
         tripDao.updateWheelMeta(trip.id, meta.toString())
+        resyncEditedTrip(trip.id)
         return true
+    }
+
+    /**
+     * Give a trip a rider-set name (blank clears it, falling back to the date).
+     *
+     * The name is written into the CSV Extra column as `trip.name=` so it
+     * survives export and a Dropbox round-trip with no sidecar file, and cached
+     * on the DB row for a fast list / title. Same atomic .rewrite -> .bak swap
+     * as [changeTripWheel] so a mid-write kill can never leave the rider with
+     * neither file. Re-syncs afterwards.
+     */
+    suspend fun renameTrip(trip: TripRecord, name: String): Boolean {
+        val clean = name.trim().take(60)
+        val file = getTripFile(trip)
+        if (file.exists()) {
+            val tmp = File(file.parentFile, file.name + ".rewrite")
+            val ok = runCatching { TripDerive.rewriteTripName(file, tmp, clean) >= 0 }
+                .getOrElse { e ->
+                    Log.e(TAG, "Trip name rewrite failed for ${trip.fileName}", e)
+                    runCatching { tmp.delete() }
+                    false
+                }
+            if (ok && tmp.exists()) {
+                val bak = File(file.parentFile, file.name + ".bak")
+                runCatching { bak.delete() }
+                if (file.renameTo(bak) && tmp.renameTo(file)) {
+                    runCatching { bak.delete() }
+                } else {
+                    runCatching { if (!file.exists()) bak.renameTo(file) }
+                    runCatching { tmp.delete() }
+                    Log.e(TAG, "Could not swap in the renamed ${trip.fileName}")
+                }
+            }
+        }
+        tripDao.updateCustomName(trip.id, clean.ifBlank { null })
+        resyncEditedTrip(trip.id)
+        return true
+    }
+
+    /**
+     * Push a trip whose file was edited in place (rename / change wheel) back to
+     * the backup folder and Dropbox. The folder worker only walks uploadStatus
+     * 1/3, so the row is re-flagged first; Dropbox re-uploads on a size change.
+     * Best-effort and gated on the rider having each destination configured.
+     */
+    private suspend fun resyncEditedTrip(tripId: Long) {
+        val appSettings = settingsRepository.get()
+        if (appSettings.syncFolderUri != null) {
+            runCatching { tripDao.markPendingFolderUpload(tripId) }
+            runCatching { syncManager.enqueueTripUpload(appSettings) }
+        }
+        if (appSettings.dropboxAccessToken.isNotBlank()) {
+            runCatching { syncManager.enqueueDropboxSync() }
+        }
     }
 
     /**

--- a/app/src/main/java/com/eried/eucplanet/data/store/SettingsJson.kt
+++ b/app/src/main/java/com/eried/eucplanet/data/store/SettingsJson.kt
@@ -190,6 +190,7 @@ object SettingsJson {
         put("tripChartOrder", s.tripChartOrder)
         put("tripHiddenCharts", s.tripHiddenCharts)
         put("tripExtraCharts", s.tripExtraCharts)
+        put("tripExtraTiles", s.tripExtraTiles)
         put("widgetMetrics", s.widget.metrics)
         put("widgetActions", s.widget.actions)
         put("widgetStandaloneActions", s.widget.standaloneActions)
@@ -514,6 +515,7 @@ object SettingsJson {
         tripChartOrder = j.optString("tripChartOrder", base.tripChartOrder),
         tripHiddenCharts = j.optString("tripHiddenCharts", base.tripHiddenCharts),
         tripExtraCharts = j.optString("tripExtraCharts", base.tripExtraCharts),
+        tripExtraTiles = j.optString("tripExtraTiles", base.tripExtraTiles),
         widget = com.eried.eucplanet.data.model.WidgetSettings(
             metrics = j.optString("widgetMetrics", base.widget.metrics),
             actions = j.optString("widgetActions", base.widget.actions),

--- a/app/src/main/java/com/eried/eucplanet/di/AppModule.kt
+++ b/app/src/main/java/com/eried/eucplanet/di/AppModule.kt
@@ -188,6 +188,15 @@ object AppModule {
         }
     }
 
+    // Custom trip name (null = fall back to the date). The name also travels
+    // inside the CSV Extra column as trip.name=, so this DB copy is just a fast
+    // cache for the list and detail title without reparsing the file.
+    private val MIGRATION_55_56 = object : Migration(55, 56) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE trips ADD COLUMN customName TEXT")
+        }
+    }
+
     /**
      * Build the Room database with the v44->v45 migration. If the open still
      * fails (e.g. a future identity-hash mismatch from a forgotten migration),
@@ -212,7 +221,7 @@ object AppModule {
 
     private fun buildDb(context: Context): AppDatabase =
         Room.databaseBuilder(context, AppDatabase::class.java, DB_NAME)
-            .addMigrations(MIGRATION_44_45, MIGRATION_45_46, MIGRATION_46_47, MIGRATION_47_48, MIGRATION_48_49, MIGRATION_49_50, MIGRATION_50_51, MIGRATION_51_52, MIGRATION_52_53, MIGRATION_53_54, MIGRATION_54_55)
+            .addMigrations(MIGRATION_44_45, MIGRATION_45_46, MIGRATION_46_47, MIGRATION_47_48, MIGRATION_48_49, MIGRATION_49_50, MIGRATION_50_51, MIGRATION_51_52, MIGRATION_52_53, MIGRATION_53_54, MIGRATION_54_55, MIGRATION_55_56)
             .build()
 
     @Provides

--- a/app/src/main/java/com/eried/eucplanet/ui/recording/RecordingScreen.kt
+++ b/app/src/main/java/com/eried/eucplanet/ui/recording/RecordingScreen.kt
@@ -120,6 +120,7 @@ fun RecordingScreen(
     var tripToDelete by remember { mutableStateOf<TripRecord?>(null) }
     // Trip whose tools sheet is open, and which tool it drilled into.
     var tripForTools by remember { mutableStateOf<TripRecord?>(null) }
+    var renameToolTrip by remember { mutableStateOf<TripRecord?>(null) }
     var wheelToolTrip by remember { mutableStateOf<TripRecord?>(null) }
     var splitToolTrip by remember { mutableStateOf<TripRecord?>(null) }
     var combineToolTrip by remember { mutableStateOf<TripRecord?>(null) }
@@ -207,9 +208,21 @@ fun RecordingScreen(
         TripToolsDialog(
             trip = trip,
             onDismiss = { tripForTools = null },
+            onRename = { renameToolTrip = trip },
             onChangeWheel = { wheelToolTrip = trip },
             onSplit = { splitToolTrip = trip },
             onCombine = { combineToolTrip = trip },
+        )
+    }
+
+    renameToolTrip?.let { trip ->
+        RenameTripDialog(
+            currentName = trip.customName,
+            onConfirm = { name ->
+                viewModel.renameTrip(trip, name)
+                renameToolTrip = null
+            },
+            onDismiss = { renameToolTrip = null },
         )
     }
 
@@ -616,7 +629,9 @@ private fun TripCard(
             }
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    dateFormat.format(Date(trip.startTime)),
+                    // Rider's custom name when set, otherwise the ride's date.
+                    trip.customName?.takeIf { it.isNotBlank() }
+                        ?: dateFormat.format(Date(trip.startTime)),
                     style = MaterialTheme.typography.bodyLarge,
                     color = if (isRecording) MaterialTheme.appColors.statusDanger else MaterialTheme.colorScheme.onSurface
                 )

--- a/app/src/main/java/com/eried/eucplanet/ui/recording/RecordingScreen.kt
+++ b/app/src/main/java/com/eried/eucplanet/ui/recording/RecordingScreen.kt
@@ -256,7 +256,7 @@ fun RecordingScreen(
     }
 
     combineToolTrip?.let { trip ->
-        val dateFmt = remember { SimpleDateFormat("dd MMM yyyy HH:mm", Locale.getDefault()) }
+        val dateFmt = remember { java.text.DateFormat.getDateTimeInstance(java.text.DateFormat.MEDIUM, java.text.DateFormat.SHORT, Locale.getDefault()) }
         CombineTripsDialog(
             anchor = trip,
             // Finished trips only: a recording still being written has no end and
@@ -571,7 +571,7 @@ private fun TripCard(
     onRetryOnline: () -> Unit = {}
 ) {
     val distanceUnitLabel = com.eried.eucplanet.util.Units.distanceUnit(distanceUnit)
-    val dateFormat = SimpleDateFormat("dd MMM yyyy HH:mm", Locale.getDefault())
+    val dateFormat = java.text.DateFormat.getDateTimeInstance(java.text.DateFormat.MEDIUM, java.text.DateFormat.SHORT, Locale.getDefault())
     val disabledColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
 
     // Live ticking elapsed time for the recording trip
@@ -703,7 +703,7 @@ private fun PendingStatusIcon() {
 
 @Composable
 private fun UploadStatusIcon(trip: TripRecord) {
-    val fmt = remember { SimpleDateFormat("dd MMM yyyy HH:mm", Locale.getDefault()) }
+    val fmt = remember { java.text.DateFormat.getDateTimeInstance(java.text.DateFormat.MEDIUM, java.text.DateFormat.SHORT, Locale.getDefault()) }
 
     val uploadedAtText = trip.uploadedAt?.let { fmt.format(Date(it)) }
     val msg = uploadedAtText?.let {

--- a/app/src/main/java/com/eried/eucplanet/ui/recording/RecordingViewModel.kt
+++ b/app/src/main/java/com/eried/eucplanet/ui/recording/RecordingViewModel.kt
@@ -187,6 +187,12 @@ class RecordingViewModel @Inject constructor(
         .map { csvToList(it.tripExtraCharts).toSet() }
         .stateIn(viewModelScope, kotlinx.coroutines.flow.SharingStarted.Eagerly, emptySet())
 
+    /** Extra stat tiles the rider switched on (start battery, energy, consumption).
+     *  Empty = the original tiles only. */
+    val tripExtraTiles: StateFlow<Set<String>> = settingsRepository.settings
+        .map { csvToList(it.tripExtraTiles).toSet() }
+        .stateIn(viewModelScope, kotlinx.coroutines.flow.SharingStarted.Eagerly, emptySet())
+
     /** Show or hide a stat tile, persisting the compact hidden-keys CSV. */
     fun setTileHidden(key: String, hidden: Boolean) {
         viewModelScope.launch {
@@ -224,6 +230,19 @@ class RecordingViewModel @Inject constructor(
         }
     }
 
+    /** Switch an opt-in extra stat tile on or off. Same inverted store as
+     *  [setExtraChart]: these ship OFF, so the set records only what was
+     *  switched ON. */
+    fun setExtraTile(key: String, enabled: Boolean) {
+        viewModelScope.launch {
+            settingsRepository.update { s ->
+                val cur = csvToList(s.tripExtraTiles).toMutableSet()
+                if (enabled) cur.add(key) else cur.remove(key)
+                s.copy(tripExtraTiles = cur.joinToString(","))
+            }
+        }
+    }
+
     /** Persist the rider's stat-tile display order as a compact CSV of tile keys. */
     fun setTileOrder(order: List<String>) {
         viewModelScope.launch {
@@ -248,6 +267,7 @@ class RecordingViewModel @Inject constructor(
                     tripHiddenTiles = "",
                     tripHiddenCharts = "",
                     tripExtraCharts = "",
+                    tripExtraTiles = "",
                     tripTileOrder = "",
                     tripChartOrder = "",
                 )

--- a/app/src/main/java/com/eried/eucplanet/ui/recording/RecordingViewModel.kt
+++ b/app/src/main/java/com/eried/eucplanet/ui/recording/RecordingViewModel.kt
@@ -796,6 +796,15 @@ class RecordingViewModel @Inject constructor(
         }
     }
 
+    /** Rename a trip (blank clears it). Writes the name into the CSV and DB and
+     *  re-syncs the file to the folder / Dropbox. */
+    fun renameTrip(trip: TripRecord, name: String) {
+        viewModelScope.launch {
+            tripRepository.renameTrip(trip, name)
+            _toasts.send(context.getString(R.string.trip_tools_renamed))
+        }
+    }
+
     /**
      * Cut points this trip plausibly contains, for the rider to choose from.
      * Reads the CSV off the main thread; a long ride is a lot of rows.

--- a/app/src/main/java/com/eried/eucplanet/ui/recording/TripDetailScreen.kt
+++ b/app/src/main/java/com/eried/eucplanet/ui/recording/TripDetailScreen.kt
@@ -192,6 +192,8 @@ fun TripDetailScreen(
     // Opt-in extra graphs (smoothed variants, power, altitude) and the window
     // the smoothed ones average over.
     val extraCharts by viewModel.tripExtraCharts.collectAsState()
+    // Opt-in extra stat tiles (start->end battery, energy, consumption).
+    val extraTiles by viewModel.tripExtraTiles.collectAsState()
     val smoothWindow by viewModel.smoothingWindowSamples.collectAsState()
 
     // Render the ViewModel's messages (e.g. "Preparing the link…", share
@@ -263,7 +265,7 @@ fun TripDetailScreen(
         reveal.cancel()
     }
 
-    val dateFormat = SimpleDateFormat("dd MMM yyyy HH:mm", Locale.getDefault())
+    val dateFormat = java.text.DateFormat.getDateTimeInstance(java.text.DateFormat.MEDIUM, java.text.DateFormat.SHORT, Locale.getDefault())
     val landscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
 
     // Trip metrics and the header date range (start -> end) are hoisted so the
@@ -389,7 +391,7 @@ fun TripDetailScreen(
                 // carrying current or PWM are counted optimistically; being one
                 // card out is invisible next to showing the wrong shape.
                 val skeletonTiles = applyOrder(TILE_KEYS_DEFAULT, savedTileOrder)
-                    .count { it !in hiddenTiles }
+                    .count { it !in hiddenTiles && (it !in EXTRA_TILE_KEYS || it in extraTiles) }
                 val skeletonCharts = applyOrder(CHART_KEYS_DEFAULT, savedChartOrder)
                     .count { it !in hiddenCharts && (it !in EXTRA_CHART_KEYS || it in extraCharts) }
                 TripDetailSkeleton(
@@ -660,6 +662,17 @@ fun TripDetailScreen(
                         Modifier.weight(1f)
                     )
                 },
+                // Opt-in (EXTRA_TILE_KEYS): the session's real start -> end %, which
+                // survives a mid-trip charge on a combined ride where max -> min does
+                // not. Title shows total drained.
+                "batteryRange" to {
+                    SummaryCard(
+                        stringResource(R.string.recording_summary_battery_range, batteryStats.batteryDrained),
+                        stringResource(R.string.recording_summary_battery_fmt, batteryStats.batteryStart, batteryStats.batteryEnd),
+                        if (batteryStats.batteryEnd < 20) MaterialTheme.appColors.statusDanger else MaterialTheme.appColors.statusGood,
+                        Modifier.weight(1f)
+                    )
+                },
                 "voltage" to {
                     SummaryCard(
                         stringResource(R.string.recording_summary_voltage),
@@ -776,7 +789,9 @@ fun TripDetailScreen(
             // Render the shown tiles in the rider's order, in rows of 3, padding a
             // short final row with spacers so every tile keeps the same width.
             val summaryCards: @Composable ColumnScope.() -> Unit = {
-                val visibleTiles = orderedTiles.filter { it.first !in hiddenTiles }
+                val visibleTiles = orderedTiles.filter {
+                    it.first !in hiddenTiles && (it.first !in EXTRA_TILE_KEYS || it.first in extraTiles)
+                }
                 visibleTiles.chunked(3).forEachIndexed { rowIndex, rowTiles ->
                     if (rowIndex > 0) Spacer(Modifier.height(8.dp))
                     Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -933,9 +948,12 @@ fun TripDetailScreen(
                 // Generic label for the sheet only: the real tile still shows the
                 // per-trip "Battery (-X%)"; the customizer must stay value-free.
                 "battery" to stringResource(R.string.metric_chip_battery),
+                "batteryRange" to stringResource(R.string.metric_chip_battery_range),
                 "voltage" to stringResource(R.string.recording_summary_voltage),
                 "maxTemp" to stringResource(R.string.recording_summary_max_temp),
                 "maxPwm" to stringResource(R.string.recording_summary_max_pwm),
+                "energy" to stringResource(R.string.recording_summary_energy),
+                "consumption" to stringResource(R.string.recording_summary_consumption),
                 "maxCurrent" to stringResource(R.string.recording_summary_max_current),
                 "maxPower" to stringResource(R.string.recording_summary_max_power),
             )
@@ -959,17 +977,19 @@ fun TripDetailScreen(
                     hiddenTiles = hiddenTiles,
                     tileOrder = effectiveTileOrder,
                     tileLabels = tileLabels,
+                    extraTiles = extraTiles,
                     hiddenCharts = hiddenCharts,
                     chartOrder = effectiveChartOrder,
                     chartLabels = chartLabels,
                     extraCharts = extraCharts,
                     onToggleTile = { key, hidden -> viewModel.setTileHidden(key, hidden) },
+                    onToggleExtraTile = { key, on -> viewModel.setExtraTile(key, on) },
                     onToggleChart = { key, hidden -> viewModel.setChartHidden(key, hidden) },
                     onToggleExtraChart = { key, on -> viewModel.setExtraChart(key, on) },
                     onReorderTiles = { viewModel.setTileOrder(it) },
                     onReorderCharts = { viewModel.setChartOrder(it) },
                     canReset = hiddenTiles.isNotEmpty() || hiddenCharts.isNotEmpty() ||
-                        extraCharts.isNotEmpty() ||
+                        extraCharts.isNotEmpty() || extraTiles.isNotEmpty() ||
                         savedTileOrder.isNotEmpty() || savedChartOrder.isNotEmpty(),
                     onReset = { viewModel.resetTripLayout() },
                     onDismiss = { showCustomize = false },
@@ -1111,11 +1131,13 @@ private fun CustomizeSheet(
     hiddenTiles: Set<String>,
     tileOrder: List<String>,
     tileLabels: Map<String, String>,
+    extraTiles: Set<String>,
     hiddenCharts: Set<String>,
     chartOrder: List<String>,
     chartLabels: Map<String, String>,
     extraCharts: Set<String>,
     onToggleTile: (String, Boolean) -> Unit,
+    onToggleExtraTile: (String, Boolean) -> Unit,
     onToggleChart: (String, Boolean) -> Unit,
     onToggleExtraChart: (String, Boolean) -> Unit,
     onReorderTiles: (List<String>) -> Unit,
@@ -1177,9 +1199,17 @@ private fun CustomizeSheet(
                                 modifier = Modifier.weight(1f),
                                 color = MaterialTheme.appColors.textPrimary,
                             )
+                            // One list, two stores - same split as the graphs:
+                            // tiles that ship on are tracked by what was HID,
+                            // the opt-in ones by what was switched ON.
+                            val isExtra = tileKey in EXTRA_TILE_KEYS
                             Switch(
-                                checked = tileKey !in hiddenTiles,
-                                onCheckedChange = { onToggleTile(tileKey, !it) },
+                                checked = if (isExtra) tileKey in extraTiles
+                                          else tileKey !in hiddenTiles,
+                                onCheckedChange = {
+                                    if (isExtra) onToggleExtraTile(tileKey, it)
+                                    else onToggleTile(tileKey, !it)
+                                },
                                 colors = themedSwitchColors(),
                             )
                         }
@@ -1521,7 +1551,20 @@ private const val SKELETON_REVEAL_MS = 120L
  */
 private val TILE_KEYS_DEFAULT = listOf(
     "distance", "duration", "points", "topSpeed", "avgSpeed", "avgMoving",
-    "battery", "voltage", "maxTemp", "maxPwm", "maxCurrent", "maxPower",
+    "battery", "batteryRange", "voltage", "maxTemp", "maxPwm",
+    "energy", "consumption", "maxCurrent", "maxPower",
+)
+
+/**
+ * Stat tiles that ship OFF, opt-in via the customizer. Same reasoning as
+ * [EXTRA_CHART_KEYS]: the tripHiddenTiles store records only what was HIDDEN, so
+ * it can't express "new and off until asked for". These live in the inverted
+ * tripExtraTiles store instead. `batteryRange` is the combined-trip-friendly
+ * start->end readout; `energy` / `consumption` were previously defined but never
+ * wired into the default order, so this also makes them reachable at last.
+ */
+private val EXTRA_TILE_KEYS = setOf(
+    "batteryRange", "energy", "consumption",
 )
 
 private val EXTRA_CHART_KEYS = setOf(
@@ -2380,6 +2423,18 @@ data class TripBatteryStats(
     val batteryMax: Int,
     val batteryMin: Int,
     val batteryConsumption: Int,
+    /** First valid battery reading (the session's true start %). Unlike
+     *  [batteryMax] this survives a mid-trip charge or regen: for a combined
+     *  trip that recharged between segments, the start is the earliest
+     *  segment's start, not the highest sample. */
+    val batteryStart: Int,
+    /** Last valid battery reading before the end-of-trip cliff (true end %). */
+    val batteryEnd: Int,
+    /** Total percent drained = sum of downward steps across valid samples.
+     *  Equals [batteryStart] - [batteryEnd] for a monotonic ride; for a
+     *  combined trip with a mid-charge it counts the real energy used
+     *  instead of pretending the recharge never happened. */
+    val batteryDrained: Int,
     val voltageMax: Float,
     val voltageMin: Float,
     /** Peak PWM / motor load (%) over valid non-NaN points. NaN when the trip has no PWM data. */
@@ -2424,7 +2479,7 @@ data class TripBatteryStats(
  */
 private fun computeBatteryStats(points: List<TripDataPoint>): TripBatteryStats {
     if (points.isEmpty()) {
-        return TripBatteryStats(0, 0, 0, 0f, 0f, Float.NaN, Float.NaN, Float.NaN)
+        return TripBatteryStats(0, 0, 0, 0, 0, 0, 0f, 0f, Float.NaN, Float.NaN, Float.NaN)
     }
 
     val endIdx = trimEndIndex(points)
@@ -2433,6 +2488,11 @@ private fun computeBatteryStats(points: List<TripDataPoint>): TripBatteryStats {
     val validBatteries = mutableListOf<Int>()
     val validVoltages = mutableListOf<Float>()
     var lastValidBattery: Int? = null
+    // Session start/end and total drained, walked in time order alongside the
+    // extremes. start = first valid sample, end = last valid sample (before the
+    // cliff), drained = sum of downward steps so a mid-charge counts honestly.
+    var firstValidBattery: Int? = null
+    var drained = 0
     // Peak PWM / current / power over the same validity mask. Tracked as a
     // running max so a single walk feeds every maximum; NaN samples are skipped.
     var maxPwm = Float.NaN
@@ -2444,6 +2504,8 @@ private fun computeBatteryStats(points: List<TripDataPoint>): TripBatteryStats {
             p.voltage > 0f &&
             (lastValidBattery == null || p.battery >= lastValidBattery!! - 10)
         if (valid) {
+            if (firstValidBattery == null) firstValidBattery = p.battery
+            lastValidBattery?.let { prev -> if (p.battery < prev) drained += prev - p.battery }
             validBatteries.add(p.battery)
             validVoltages.add(p.voltage)
             lastValidBattery = p.battery
@@ -2468,6 +2530,9 @@ private fun computeBatteryStats(points: List<TripDataPoint>): TripBatteryStats {
             batteryMax = rawBatMax,
             batteryMin = rawBatMin,
             batteryConsumption = (rawBatMax - rawBatMin).coerceAtLeast(0),
+            batteryStart = points.first().battery,
+            batteryEnd = points.last().battery,
+            batteryDrained = (points.first().battery - points.last().battery).coerceAtLeast(0),
             voltageMax = rawVoltMax,
             voltageMin = rawVoltMin,
             maxPwm = maxPwm,
@@ -2482,6 +2547,9 @@ private fun computeBatteryStats(points: List<TripDataPoint>): TripBatteryStats {
         batteryMax = batMax,
         batteryMin = batMin,
         batteryConsumption = (batMax - batMin).coerceAtLeast(0),
+        batteryStart = firstValidBattery ?: batMax,
+        batteryEnd = lastValidBattery ?: batMin,
+        batteryDrained = drained,
         voltageMax = validVoltages.max(),
         voltageMin = validVoltages.min(),
         maxPwm = maxPwm,

--- a/app/src/main/java/com/eried/eucplanet/ui/recording/TripDetailScreen.kt
+++ b/app/src/main/java/com/eried/eucplanet/ui/recording/TripDetailScreen.kt
@@ -299,6 +299,9 @@ fun TripDetailScreen(
             timeFormat.format(Date(endMs)) else dateFormat.format(Date(endMs))
         "${dateFormat.format(Date(startMs))} → $endText"
     }
+    // Rider's custom name leads the header when set (matching the trip list and
+    // eucviewer's inspector); otherwise the start -> end date range stands in.
+    val tripTitle = trip.customName?.takeIf { it.isNotBlank() } ?: headerDateTime
 
     Scaffold(
         topBar = {
@@ -325,7 +328,7 @@ fun TripDetailScreen(
                     }
                     if (dataPoints.isNotEmpty()) {
                         Text(
-                            headerDateTime,
+                            tripTitle,
                             style = MaterialTheme.typography.titleMedium,
                             color = MaterialTheme.colorScheme.onSurface,
                             modifier = Modifier.align(Alignment.Center),
@@ -1043,7 +1046,7 @@ fun TripDetailScreen(
                 ) {
                     Spacer(Modifier.height(8.dp))
                     Text(
-                        headerDateTime,
+                        tripTitle,
                         style = MaterialTheme.typography.titleMedium,
                         color = MaterialTheme.colorScheme.onSurface,
                     )

--- a/app/src/main/java/com/eried/eucplanet/ui/recording/TripToolsDialog.kt
+++ b/app/src/main/java/com/eried/eucplanet/ui/recording/TripToolsDialog.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.CallMerge
 import androidx.compose.material.icons.filled.ContentCut
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
@@ -65,6 +66,7 @@ import com.eried.eucplanet.ui.theme.themedFieldColors
 fun TripToolsDialog(
     trip: TripRecord,
     onDismiss: () -> Unit,
+    onRename: () -> Unit,
     onChangeWheel: () -> Unit,
     onSplit: () -> Unit,
     onCombine: () -> Unit,
@@ -75,6 +77,11 @@ fun TripToolsDialog(
         title = { Text(stringResource(R.string.trip_tools_title)) },
         text = {
             Column {
+                ToolRow(
+                    Icons.Default.Edit,
+                    stringResource(R.string.trip_tools_rename),
+                    stringResource(R.string.trip_tools_rename_desc),
+                ) { onDismiss(); onRename() }
                 ToolRow(
                     // Not a vehicle glyph. This tool changes a LABEL, and the
                     // repo's terminology rule is that the device is a wheel,
@@ -96,6 +103,51 @@ fun TripToolsDialog(
             }
         },
         confirmButton = {},
+        dismissButton = {
+            TextButton(onClick = onDismiss, shape = RoundedCornerShape(12.dp)) {
+                Text(stringResource(R.string.action_cancel))
+            }
+        }
+    )
+}
+
+/**
+ * Give a trip a name. Blank clears it, and the trip falls back to its date.
+ * The name is capped at 60 chars to match the CSV reader (and eucviewer).
+ */
+@Composable
+fun RenameTripDialog(
+    currentName: String?,
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var text by remember { mutableStateOf(currentName.orEmpty()) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        shape = RoundedCornerShape(12.dp),
+        title = { Text(stringResource(R.string.trip_tools_rename)) },
+        text = {
+            Column {
+                Text(
+                    stringResource(R.string.trip_tools_rename_hint),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.appColors.textSecondary,
+                )
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = text,
+                    onValueChange = { text = it.take(60) },
+                    singleLine = true,
+                    colors = themedFieldColors(),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(text.trim()) }, shape = RoundedCornerShape(12.dp)) {
+                Text(stringResource(R.string.action_save))
+            }
+        },
         dismissButton = {
             TextButton(onClick = onDismiss, shape = RoundedCornerShape(12.dp)) {
                 Text(stringResource(R.string.action_cancel))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -220,6 +220,7 @@
 
     <!-- Metric labels for the dashboard layout chips -->
     <string name="metric_chip_battery">Battery</string>
+    <string name="metric_chip_battery_range">Battery start → end</string>
     <string name="metric_chip_temperature">Temperature</string>
     <string name="metric_chip_voltage">Voltage</string>
     <string name="metric_chip_current">Amps</string>
@@ -1213,6 +1214,7 @@
     <string name="recording_summary_energy">Energy</string>
     <string name="recording_summary_consumption">Consumption</string>
     <string name="recording_summary_battery">Battery (-%1$d%%)</string>
+    <string name="recording_summary_battery_range">Start→end (-%1$d%%)</string>
     <string name="recording_summary_voltage">Voltage</string>
     <string name="recording_summary_avg_moving">Avg Moving</string>
     <string name="recording_summary_battery_fmt">%1$d→%2$d%%</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1287,6 +1287,10 @@
     <string name="trip_section_saved">Section saved as a new trip</string>
     <string name="trip_section_failed">Could not save the section</string>
     <string name="trip_tools_title">Trip tools</string>
+    <string name="trip_tools_rename">Rename trip</string>
+    <string name="trip_tools_rename_desc">Give this ride a name. Stored in its file, so it travels with exports and sync.</string>
+    <string name="trip_tools_rename_hint">Leave blank to use the date.</string>
+    <string name="trip_tools_renamed">Trip renamed</string>
     <string name="trip_tools_change_wheel">Change wheel</string>
     <string name="trip_tools_change_wheel_desc">Correct which wheel this ride was on. Updates the trip and its file.</string>
     <string name="trip_tools_wheel_other">Another wheel</string>

--- a/app/src/test/java/com/eried/eucplanet/data/TripDeriveTest.kt
+++ b/app/src/test/java/com/eried/eucplanet/data/TripDeriveTest.kt
@@ -100,4 +100,67 @@ class TripDeriveTest {
         val dest = File(tmp.root, "joined3.csv")
         assertEquals(0, TripDerive.writeJoined(listOf(File(tmp.root, "gone.csv")), dest))
     }
+
+    // --- rewriteTripName (custom trip names, eucviewer-compatible) ---
+
+    private val headerExtra = "$header,Extra"
+
+    /** A CSV with an Extra column; [extras] is the Extra cell for each row. */
+    private fun extraCsv(name: String, extras: List<String>): File {
+        val f = tmp.newFile(name)
+        f.bufferedWriter().use { w ->
+            w.write(headerExtra); w.newLine()
+            extras.forEachIndexed { i, ex ->
+                w.write("2026-08-09 12:00:%02d.000,10,80,30,90,100,1.0,2.0,5.$i,$ex".format(i))
+                w.newLine()
+            }
+        }
+        return f
+    }
+
+    private fun tripNameCount(text: String) =
+        Regex("trip\\.name=", RegexOption.IGNORE_CASE).findAll(text).count()
+
+    @Test fun rewriteTripName_writesTheNameIntoTheFirstEmptyExtraCell() {
+        val src = extraCsv("n1.csv", listOf("", "wheel.name=V14", ""))
+        val dest = File(tmp.root, "n1_out.csv")
+        assertEquals(1, TripDerive.rewriteTripName(src, dest, "Morning commute"))
+        val text = dest.readText()
+        assertTrue(text.contains("trip.name=Morning commute")) // exact form eucviewer reads
+        assertEquals(1, tripNameCount(text))
+        assertTrue(text.contains("wheel.name=V14"))            // wheel identity untouched
+    }
+
+    @Test fun rewriteTripName_replacesAnExistingNameSoOnlyOneRemains() {
+        val src = extraCsv("n2.csv", listOf("trip.name=Old", "", ""))
+        val dest = File(tmp.root, "n2_out.csv")
+        TripDerive.rewriteTripName(src, dest, "New name")
+        val text = dest.readText()
+        assertTrue(text.contains("trip.name=New name"))
+        assertFalse(text.contains("trip.name=Old"))
+        assertEquals(1, tripNameCount(text))
+    }
+
+    @Test fun rewriteTripName_blankClearsTheName() {
+        val src = extraCsv("n3.csv", listOf("trip.name=Old", ""))
+        val dest = File(tmp.root, "n3_out.csv")
+        TripDerive.rewriteTripName(src, dest, "")
+        assertEquals(0, tripNameCount(dest.readText()))
+    }
+
+    @Test fun rewriteTripName_withNoExtraColumn_isZeroAndSafe() {
+        val src = csv("n4.csv", 2) // header carries no Extra column
+        val dest = File(tmp.root, "n4_out.csv")
+        assertEquals(0, TripDerive.rewriteTripName(src, dest, "Whatever"))
+    }
+
+    @Test fun rewriteTripName_sanitisesCommasSoFramingSurvives() {
+        val src = extraCsv("n5.csv", listOf("", ""))
+        val dest = File(tmp.root, "n5_out.csv")
+        TripDerive.rewriteTripName(src, dest, "A, B, C")
+        val lines = dest.readLines().filter { it.isNotBlank() }
+        val cols = lines.first().split(",").size
+        lines.drop(1).forEach { assertEquals(cols, it.split(",").size) } // no extra columns
+        assertTrue(dest.readText().contains("trip.name=A B C"))
+    }
 }

--- a/app/src/test/java/com/eried/eucplanet/data/eucstats/EucStatsRepositoryTest.kt
+++ b/app/src/test/java/com/eried/eucplanet/data/eucstats/EucStatsRepositoryTest.kt
@@ -132,6 +132,16 @@ class FakeTripDao : TripDao {
         if (idx >= 0) trips[idx] = trips[idx].copy(wheelMetaJson = json)
     }
 
+    override suspend fun updateCustomName(id: Long, name: String?) {
+        val idx = trips.indexOfFirst { it.id == id }
+        if (idx >= 0) trips[idx] = trips[idx].copy(customName = name)
+    }
+
+    override suspend fun markPendingFolderUpload(id: Long) {
+        val idx = trips.indexOfFirst { it.id == id }
+        if (idx >= 0) trips[idx] = trips[idx].copy(uploadStatus = 1)
+    }
+
     override suspend fun allWheelMeta(): List<String> = trips.mapNotNull { it.wheelMetaJson }
     override suspend fun getUnfinished(): List<TripRecord> = trips.filter { it.endTime == null }
     override suspend fun findByFileName(name: String): TripRecord? =


### PR DESCRIPTION
Trip Details work, two things.

## 1. Combined-trip battery + locale dates
- **Battery start → end**: new opt-in tile (off by default; enable in the tile customizer). The existing tile shows `max → min`, which on a combined ride that recharged between segments latches the max onto the mid-trip charge peak, so a real 98%→28% day can read 100→28. The new tile reads the first and last *valid* samples and reports total drained (sum of downward steps, honest across a mid-charge). The existing tile is untouched.
- Revived the **energy/consumption** tiles: they were in `allTiles` but missing from `TILE_KEYS_DEFAULT`, so they never rendered in release and the debug drift-guard threw on opening a trip. All three optional tiles now live in a new `EXTRA_TILE_KEYS` "ships off" set mirroring `EXTRA_CHART_KEYS`.
- **Dates** are locale-aware now (`DateFormat.getDateTimeInstance`), so US devices show month-first ("Aug 18, 2026") instead of hardcoded day-first.

## 2. Rename trips + auto-sync edits
- **Rename trip** in the tools menu (before Change wheel). Blank clears it → falls back to the date. The name is written into the CSV Extra column as a single `trip.name=` pair (the exact form eucviewer reads), so it survives export and a Dropbox round-trip with no sidecar; cached on a new nullable `TripRecord.customName` (DB v55→56) for a fast list/title. Re-rename replaces the existing pair. List + detail header lead with the name when set.
- **Auto-sync on edit**: `changeTripWheel` rewrote the CSV in place but never re-flagged `uploadStatus` or enqueued a sync, so an already-uploaded edited trip went stale in the backup folder (worker only walks status 1/3) and on Dropbox. Both rename and change-wheel now call a shared `resyncEditedTrip` (re-flag + enqueue folder + Dropbox). Filename never changes, so nothing orphans remotely.
- Tests: `TripDeriveTest` covers the `trip.name=` upsert (insert / replace-to-one / clear / no-Extra-column / comma-sanitise).

## Before merge
- **Localize** the new strings (rename dialog + battery-range tile) to all 14 locales - en-US only on this branch.
- **On-device**: combine a mid-charge day and confirm the start→end tile; rename a trip and confirm it syncs to folder/Dropbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GADLyChheAoMX9dQbRgRnH
