### PR TITLE
Fix NOSFET Aeon headlight command mapping

### DIFF
--- a/app/src/main/java/com/eried/eucplanet/ble/VeteranAdapter.kt
+++ b/app/src/main/java/com/eried/eucplanet/ble/VeteranAdapter.kt
@@ -40,6 +40,8 @@ class VeteranAdapter @Inject constructor() : WheelAdapter {
     override val capabilities = WheelCapabilities.VETERAN
 
     @Volatile private var detectedModel: VeteranModel? = null
+    @Volatile private var controlProfile = VeteranControlProfile.forModel(null)
+    private var pendingLightProfile: VeteranControlProfile? = null
 
     override val nominalPackVoltage: Int? get() = detectedModel?.nominalVoltage
 
@@ -49,6 +51,7 @@ class VeteranAdapter @Inject constructor() : WheelAdapter {
 
     override fun notifyConnectingTo(deviceName: String?): DecodeResult.ModelName? {
         detectedModel = deviceName?.let { VeteranModel.fromReportedName(it) }
+        controlProfile = VeteranControlProfile.forModel(detectedModel)
         return null
     }
 
@@ -100,22 +103,22 @@ class VeteranAdapter @Inject constructor() : WheelAdapter {
 
     override fun setLight(on: Boolean): ByteArray {
         lastLightOn = on
-        // HIGH beam by default (LkAp frame; LdAp companion via [setLightFollowup]).
-        return VeteranCommands.setHighBeam(on)
-        // LOW beam (legacy ASCII, single frame). To switch the in-app light
-        // toggle back to the low beam: comment the high-beam return above,
-        // uncomment the line below, and make [setLightFollowup] return null.
-        // return VeteranCommands.setLight(on)
+        val profile = controlProfile
+        pendingLightProfile = profile
+        return profile.setLight(on)
     }
 
     /**
      * Second frame of the high-beam command (`LdAp`); the wheel ignores the
      * `LkAp` half from [setLight] on its own. Decoded from the same Lynx S
-     * btsnoop as the horn. If you switch [setLight] back to the low beam,
-     * change this to `null` (low beam is a single ASCII frame).
+     * btsnoop as the horn. Aeon uses a single ASCII frame and has no companion.
      */
-    override fun setLightFollowup(on: Boolean): ByteArray =
-        VeteranCommands.setHighBeamCompanion(on)
+    override fun setLightFollowup(on: Boolean): ByteArray? {
+        // Model telemetry can arrive between the two writes; finish the same mapping.
+        val profile = pendingLightProfile ?: controlProfile
+        pendingLightProfile = null
+        return profile.setLightFollowup(on)
+    }
 
     // Veteran writes tilt-back and alarm thresholds as two separate frames
     // (different magic + sub-op per setting), so we leave the combined
@@ -258,6 +261,13 @@ class VeteranAdapter @Inject constructor() : WheelAdapter {
             // the `f.isLong` branch below.
             val isStandardTelemetry =
                 f.bytes.size > 3 && f.bytes[3] != 0x5f.toByte()
+            // Generic BLE names (e.g. NF7445) do not identify the wheel. Select
+            // commands from the model in a reassembled telemetry frame as well.
+            if (isStandardTelemetry) {
+                VeteranModel.fromMVer(VeteranParser.mVerOf(f.bytes))?.let {
+                    controlProfile = VeteranControlProfile.forModel(it)
+                }
+            }
             val telem = if (isStandardTelemetry)
                 VeteranParser.parseTelemetry(f.bytes, detectedModel) else null
             val emitted = if (telem != null) {
@@ -329,6 +339,8 @@ class VeteranAdapter @Inject constructor() : WheelAdapter {
     override fun onDisconnect() {
         parser.reset()
         detectedModel = null
+        controlProfile = VeteranControlProfile.forModel(null)
+        pendingLightProfile = null
         lastOryxBatterySoc = -1
         emittedModel = false
         // A wheel reboot loses light state on the wheel side, so the rider's

--- a/app/src/main/java/com/eried/eucplanet/ble/VeteranControlProfile.kt
+++ b/app/src/main/java/com/eried/eucplanet/ble/VeteranControlProfile.kt
@@ -1,0 +1,24 @@
+package com.eried.eucplanet.ble
+
+/** Model-specific command mapping; transport, capabilities and UI stay unchanged. */
+internal interface VeteranControlProfile {
+    fun setLight(on: Boolean): ByteArray
+    fun setLightFollowup(on: Boolean): ByteArray?
+
+    companion object {
+        fun forModel(model: VeteranModel?): VeteranControlProfile =
+            if (model == VeteranModel.NOSFET_AEON) AeonControlProfile else DefaultVeteranControlProfile
+    }
+}
+
+internal object DefaultVeteranControlProfile : VeteranControlProfile {
+    override fun setLight(on: Boolean): ByteArray = VeteranCommands.setHighBeam(on)
+    override fun setLightFollowup(on: Boolean): ByteArray = VeteranCommands.setHighBeamCompanion(on)
+}
+
+internal object AeonControlProfile : VeteranControlProfile {
+    // Aeon 503002 capture: ASCII toggles OFF/LOW without the binary acknowledgement.
+    // This is not a high-beam selector and is independent of panel key-tone volume.
+    override fun setLight(on: Boolean): ByteArray = VeteranCommands.setLight(on)
+    override fun setLightFollowup(on: Boolean): ByteArray? = null
+}

--- a/app/src/test/java/com/eried/eucplanet/ble/VeteranLightTest.kt
+++ b/app/src/test/java/com/eried/eucplanet/ble/VeteranLightTest.kt
@@ -2,6 +2,7 @@ package com.eried.eucplanet.ble
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 /**
@@ -10,10 +11,49 @@ import org.junit.Test
  * The in-app light toggle drives the HIGH beam by default: a two-frame
  * `LkAp` + `LdAp` pair decoded from a LeaperKim-app btsnoop on a Lynx S
  * (high beam on @cap25.3s, off @cap28.3s). The legacy ASCII `SetLightON/OFF`
- * (low beam) stays available as a commented fallback in [VeteranAdapter].
+ * (low beam) is selected for the NOSFET Aeon only.
  * Pure-JVM test; no Android runtime needed.
  */
 class VeteranLightTest {
+    @Test
+    fun `Aeon uses single ASCII commands and disconnect restores default mapping`() {
+        val adapter = VeteranAdapter()
+        adapter.notifyConnectingTo("NOSFET Aeon")
+        for (on in listOf(true, false)) {
+            assertEquals(if (on) "SetLightON" else "SetLightOFF", adapter.setLight(on).toString(Charsets.US_ASCII))
+            assertNull(adapter.setLightFollowup(on))
+        }
+        adapter.onDisconnect()
+        assertEquals(HIGHBEAM_ON_LKAP, adapter.setLight(true).hex())
+        assertEquals(HIGHBEAM_ON_LDAP, adapter.setLightFollowup(true)!!.hex())
+    }
+
+    @Test
+    fun `generic BLE name selects Aeon commands after captured model telemetry`() {
+        val adapter = VeteranAdapter()
+        adapter.notifyConnectingTo("NF7445")
+        assertEquals(HIGHBEAM_ON_LKAP, adapter.setLight(true).hex())
+        // Owner capture 2026-09-07, Aeon 503002; original CRC included.
+        val frame = ("dc 5a 5c 47 33 f0 00 00 d4 b2 00 01 d6 9e 00 01 " +
+            "00 00 0d 22 04 6b 00 00 01 5e 01 90 ac da 07 b4 1f 14 00 00 " +
+            "80 c8 00 00 80 80 80 80 80 80 08 00 00 80 50 00 28 41 23 1e " +
+            "00 00 00 00 80 80 28 00 3e 91 32 80 00 80 80 49 e9 ce e1")
+            .split(" ").map { it.toInt(16).toByte() }.toByteArray()
+        frame.toList().chunked(20).forEach { adapter.onRawNotification(it.toByteArray()) }
+        // Finish the initial default transaction even if identification arrives mid-write.
+        assertEquals(HIGHBEAM_ON_LDAP, adapter.setLightFollowup(true)!!.hex())
+        assertEquals("SetLightON", adapter.setLight(true).toString(Charsets.US_ASCII))
+        assertNull(adapter.setLightFollowup(true))
+    }
+
+    @Test
+    fun `all other models retain the existing light pair`() {
+        for (model in VeteranModel.entries.filter { it != VeteranModel.NOSFET_AEON } + null) {
+            val profile = VeteranControlProfile.forModel(model)
+            assertEquals(HIGHBEAM_ON_LKAP, profile.setLight(true).hex())
+            assertEquals(HIGHBEAM_ON_LDAP, profile.setLightFollowup(true)!!.hex())
+        }
+    }
 
     private fun ByteArray.hex() = joinToString(" ") { "%02x".format(it) }
 

--- a/docs/protocols/aeon-mapping-repairs.md
+++ b/docs/protocols/aeon-mapping-repairs.md
@@ -1,0 +1,19 @@
+# Aeon mapping repairs
+
+Based on upstream main fac53425 (release line v0.19.0). This branch fixes existing command mappings only: no new controls, telemetry extensions, UI, capability declarations, firmware operations or experimental logging. Other Veteran models retain existing mappings.
+
+## Headlight
+
+Select existing ASCII SetLightON/OFF for Aeon, with no binary companion. This preserves the Boolean toggle, not remote selection of medium/high levels. Select by existing model identification (name or telemetry mVer44); unknown models keep the upstream mapping. No SND-based policy is introduced.
+
+Owner PC capture, Aeon 503002, 2026-09-11: ASCII ON/OFF at20:55:48/20:56:04 with SND10 toggled the light without beeps; binary pair at20:56:21/20:56:37–38 beeped. Binary pair also beeped with SND0 at20:54:48/20:55:04–05. Physical light observations and captured readbacks agree. Earlier app tests reporting ASCII-associated beeps remain historical evidence; universal silence and proportional beep amplitude are not claimed. SND is panel key-tone volume, not a basis for selecting Bluetooth light packets.
+
+Research ledger: aeon-pc-investigation-20260911.md in the owner's analysis workspace. Tests retain the upstream Lynx vectors and exercise name identification, captured Aeon telemetry identification and reset.
+
+## Firmware corroboration and scope
+
+The official Aero image downloaded on 2026-09-12 from `http://www.baat22.com:800/nfapp/firm/1/_main5020xx.bin` is byte-identical to EUC World's Aero image45. Edition502.0.06, 125236 bytes, SHA-256 `b2f213e4be112b343690a1676ab4a1ffed05b3fe6194d3e7dbd400a26176f7c6`. This is provenance from an official-app-derived endpoint plus an independent mirror match, not cryptographic manufacturer authentication.
+
+In that image, ASCII SetLightON/OFF handlers at file offsets0xe7b4/0xe7ca store1/0 to light state RAM0x20000259 without calling the binary acknowledgement-parameter routine. Binary light routes use setter0x374c, which accepts only0/1. These are **confirmed in official Aero firmware code**, independently corroborating the command-path difference observed on Aeon. Neither proves universal silence or physical operation on an Aero we have not tested.
+
+Thus these findings describe shared NOSFET protocol behavior with stronger cross-model evidence, rather than an arbitrary Aeon workaround. Runtime changes remain limited to Aeon: compatibility on other models/releases requires its own evidence. No Aero firmware was flashed to Aeon.


### PR DESCRIPTION
## Summary

Follow-up to #12, implementing the ASCII-command approach previously proposed by @eried. Thank you for the earlier beta; the later isolated tests below provide a clearer answer than the original app-level observations.

- Select the existing `SetLightON` / `SetLightOFF` commands, without a binary companion, for NOSFET Aeon.
- Retain the existing paired light commands for other Veteran models and unidentified wheels.
- Select the mapping from existing name/model identification, including telemetry `mVer=44` when the advertised name is generic (e.g. NF7445).
- Preserve the selected mapping between the first write and its follow-up if model telemetry arrives in between.

This is a correction to the existing Boolean light toggle, not a new light-mode feature. No UI, telemetry extensions, capability changes, horn changes or SND-dependent policy are included. The separate alarm-speed fix is not included here.

## Evidence

**Verified on Aeon / from capture, firmware 503002 (503.0.02), 2026-09-11:**

- ASCII ON/OFF at 20:55:48 / 20:56:04, with SND10: light changed and no beep was heard.
- Binary pair at 20:56:21 / 20:56:37–38, with SND10: light changed with beeps.
- Binary pair also beeped with SND0 at 20:54:48 / 20:55:04–05.
- Effective ON/OFF commands produced OFF/LOW readbacks. This does not add remote medium/high selection.

Earlier app tests reporting ASCII-associated beeps remain historical evidence; these later isolated PC tests do not justify claiming silence on every firmware/version. SND is panel key-tone volume, not a basis for choosing the Bluetooth light protocol.

**Confirmed in official Aero firmware code, edition 502.0.06:** ASCII handlers at file offsets 0xe7b4/0xe7ca store 1/0 to light state without calling the binary acknowledgement-parameter routine. This independently corroborates the path difference observed on Aeon; it is not a physical Aero test or blanket NOSFET compatibility claim.

The image downloaded from the official-app-derived endpoint is byte-identical to EUC World's Aero image45. SHA-256: `b2f213e4be112b343690a1676ab4a1ffed05b3fe6194d3e7dbd400a26176f7c6`. Source endpoint, offsets and evidence limits are documented in `docs/protocols/aeon-mapping-repairs.md`. No firmware was flashed or distributed by this PR.

## Validation

Independently tested on this branch, based directly on upstream main `fac53425`:

```text
gradlew.bat :app:testDebugUnitTest --tests "com.eried.eucplanet.ble.*" --tests "*Legal*" --tests "*Headlight*"
142 tests passed; zero failures, errors or skips.
```

Includes existing Lynx packet vectors, Aeon name/captured-telemetry identification, mid-transaction identification, reset and unchanged mappings for other models. JVM tests do not replace physical firmware validation. No APK or live wheel operation was performed for this submission.
