### PR TITLE
Fix NOSFET Aeon alarm-speed command mapping

### DIFF
--- a/app/src/main/java/com/eried/eucplanet/ble/VeteranAdapter.kt
+++ b/app/src/main/java/com/eried/eucplanet/ble/VeteranAdapter.kt
@@ -40,6 +40,7 @@ class VeteranAdapter @Inject constructor() : WheelAdapter {
     override val capabilities = WheelCapabilities.VETERAN
 
     @Volatile private var detectedModel: VeteranModel? = null
+    @Volatile private var alarmCommandModel: VeteranModel? = null
 
     override val nominalPackVoltage: Int? get() = detectedModel?.nominalVoltage
 
@@ -49,6 +50,7 @@ class VeteranAdapter @Inject constructor() : WheelAdapter {
 
     override fun notifyConnectingTo(deviceName: String?): DecodeResult.ModelName? {
         detectedModel = deviceName?.let { VeteranModel.fromReportedName(it) }
+        alarmCommandModel = detectedModel
         return null
     }
 
@@ -127,7 +129,7 @@ class VeteranAdapter @Inject constructor() : WheelAdapter {
         VeteranCommands.setTiltbackSpeed(tiltbackKmh.toInt())
 
     override fun setAlarmSpeedCommit(alarmKmh: Float): ByteArray =
-        VeteranCommands.setAlarmSpeed(alarmKmh.toInt())
+        VeteranCommands.setAlarmSpeed(alarmKmh.toInt(), alarmCommandModel)
 
     // No volume, no DRL on this family.
     override fun setVolume(percent: Int): ByteArray? = null
@@ -258,6 +260,11 @@ class VeteranAdapter @Inject constructor() : WheelAdapter {
             // the `f.isLong` branch below.
             val isStandardTelemetry =
                 f.bytes.size > 3 && f.bytes[3] != 0x5f.toByte()
+            // Generic names such as NF7445 need the model from a complete frame.
+            // Keep command identification separate from existing telemetry/UI state.
+            if (isStandardTelemetry) {
+                VeteranModel.fromMVer(VeteranParser.mVerOf(f.bytes))?.let { alarmCommandModel = it }
+            }
             val telem = if (isStandardTelemetry)
                 VeteranParser.parseTelemetry(f.bytes, detectedModel) else null
             val emitted = if (telem != null) {
@@ -329,6 +336,7 @@ class VeteranAdapter @Inject constructor() : WheelAdapter {
     override fun onDisconnect() {
         parser.reset()
         detectedModel = null
+        alarmCommandModel = null
         lastOryxBatterySoc = -1
         emittedModel = false
         // A wheel reboot loses light state on the wheel side, so the rider's

--- a/app/src/main/java/com/eried/eucplanet/ble/VeteranCommands.kt
+++ b/app/src/main/java/com/eried/eucplanet/ble/VeteranCommands.kt
@@ -168,8 +168,19 @@ object VeteranCommands {
      * with 8-byte payload `01 80 80 80 80 80 80 [VAL]`. Verified by
      * matching wire byte 0x14 to the Alarm-speed slider reading 20 km/h.
      */
-    fun setAlarmSpeed(kmh: Int): ByteArray =
-        buildLeaperKimSpeedFrame(magic = LKAP, subOp = SUBOP_ALARM, kmh = kmh)
+    fun setAlarmSpeed(kmh: Int, model: VeteranModel? = null): ByteArray =
+        if (model == VeteranModel.NOSFET_AEON) setAeonAlarmSpeed(kmh)
+        else buildLeaperKimSpeedFrame(magic = LKAP, subOp = SUBOP_ALARM, kmh = kmh)
+
+    /** Aeon 503002 capture-verified setting readback (35 -> 34 -> 35), also
+     * confirmed at bank 2 / wire byte 14 in official Aero 502.0.06 firmware.
+     * Preserve application bounds; no off sentinel or riding-enforcement claim.
+     * See docs/protocols/aeon-alarm-speed.md for vectors and provenance. */
+    private fun setAeonAlarmSpeed(kmh: Int): ByteArray = buildVendorFrame(
+        magic = LDAP, totalLen = 19,
+        payloadHead = byteArrayOf(0x01, 0x02) + ByteArray(7) { 0x80.toByte() },
+        valueByte = kmh.coerceIn(1, 99).toByte(),
+    )
 
     // ---- Other decoded LeaperKim settings (no UI binding yet) ----
     //

--- a/app/src/test/java/com/eried/eucplanet/ble/VeteranAlarmSpeedTest.kt
+++ b/app/src/test/java/com/eried/eucplanet/ble/VeteranAlarmSpeedTest.kt
@@ -1,0 +1,57 @@
+package com.eried.eucplanet.ble
+
+import org.junit.Assert.*
+import org.junit.Test
+import java.util.zip.CRC32
+
+class VeteranAlarmSpeedTest {
+    private fun String.bytes() = chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+
+    @Test fun `Aeon alarm matches original captured packets while tiltback stays unchanged`() {
+        val adapter = VeteranAdapter()
+        adapter.notifyConnectingTo("NOSFET Aeon")
+        // PC capture 2026-09-11 21:40:19 / 21:40:36, original CRCs.
+        for ((speed, hex) in mapOf(
+            34 to "4c6441701301028080808080808022e9294692",
+            35 to "4c64417013010280808080808080239e2e7604",
+        )) {
+            assertArrayEquals(hex.bytes(), adapter.setAlarmSpeedCommit(speed.toFloat()))
+            assertArrayEquals(VeteranCommands.setTiltbackSpeed(speed), adapter.setMaxSpeedCommit(speed.toFloat()))
+        }
+        adapter.onDisconnect()
+        assertArrayEquals(VeteranCommands.setAlarmSpeed(35), adapter.setAlarmSpeedCommit(35f))
+    }
+
+    @Test fun `other models and unknown model retain the generic alarm mapping`() {
+        for (model in VeteranModel.entries.filter { it != VeteranModel.NOSFET_AEON } + null) {
+            assertArrayEquals(VeteranCommands.setAlarmSpeed(35), VeteranCommands.setAlarmSpeed(35, model))
+        }
+    }
+
+    @Test fun `Aeon alarm preserves bounds padding CRC and one ATT write`() {
+        for (speed in listOf(Int.MIN_VALUE, -1, 0, 1, 34, 35, 99, 100, 128, 200, Int.MAX_VALUE)) {
+            val frame = VeteranCommands.setAlarmSpeed(speed, VeteranModel.NOSFET_AEON)
+            assertEquals(19, frame.size)
+            assertEquals(speed.coerceIn(1, 99), frame[14].toInt() and 255)
+            assertTrue(frame.slice(7..13).all { it == 0x80.toByte() })
+            assertEquals(CRC32().apply { update(frame, 0, 15) }.value,
+                frame.takeLast(4).fold(0L) { a, b -> (a shl 8) or (b.toLong() and 255) })
+        }
+    }
+
+    @Test fun `generic BLE name resolves alarm mapping from captured Aeon telemetry`() {
+        val adapter = VeteranAdapter()
+        adapter.notifyConnectingTo("NF7445")
+        assertArrayEquals(VeteranCommands.setAlarmSpeed(35), adapter.setAlarmSpeedCommit(35f))
+        // Owner capture 2026-09-07, Aeon 503002; original CRC.
+        val frame = ("dc5a5c4733f00000d4b20001d69e0001" +
+            "00000d22046b0000015e0190acda07b41f140000" +
+            "80c800008080808080800800008050002841231e" +
+            "00000000808028003e91328000808049e9cee1").bytes()
+        frame.toList().chunked(20).forEach { adapter.onRawNotification(it.toByteArray()) }
+        assertArrayEquals("4c64417013010280808080808080239e2e7604".bytes(), adapter.setAlarmSpeedCommit(35f))
+        // This PR must not change the existing light path or introduce a companion change.
+        assertArrayEquals(VeteranCommands.setHighBeam(true), adapter.setLight(true))
+        assertArrayEquals(VeteranCommands.setHighBeamCompanion(true), adapter.setLightFollowup(true))
+    }
+}

--- a/docs/protocols/aeon-alarm-speed.md
+++ b/docs/protocols/aeon-alarm-speed.md
@@ -1,0 +1,26 @@
+# NOSFET Aeon alarm-speed mapping repair
+
+This changes only the existing alarm-speed command for identified Aeon wheels. No headlight changes, new controls, capability changes, telemetry decoding, UI, firmware operations or legal-mode flow changes. Unknown models and other Veteran models retain their existing alarm packet. The existing 1..99 km/h application clamp is preserved; no off sentinel is introduced.
+
+## Verified from Aeon capture
+
+Wheel firmware503002 (503.0.02), model key44. The generic 17-byte LkAp alarm packet did not change either alarm-setting readback in isolated PC tests. A 19-byte LdAp settings-bank2 command, value at zero-based wire14, did:
+
+```text
+2026-09-11 21:40:19.772 +03:00, 34 km/h:
+4c 64 41 70 13 01 02 80 80 80 80 80 80 80 22 e9 29 46 92
+2026-09-11 21:40:36.113 +03:00, restore 35 km/h:
+4c 64 41 70 13 01 02 80 80 80 80 80 80 80 23 9e 2e 76 04
+```
+
+Common-header alarm and page8 byte54 both changed35→34→35; tiltback stayed42. Restoration was confirmed21:40:52.474. A fresh BLE-session repeat at21:42 reproduced both changes. Original vectors, including CRC32-BE, are used in JVM tests. Research sources: owner's aeon-controlled-20260911-213954.jsonl (TX lines574/962) and aeon-investigation-backlog-20260911.md.
+
+This verifies setting acceptance/readback, not physical alarm enforcement while riding. No wheel operation is performed by the tests.
+
+## Confirmed in official Aero firmware code
+
+Aero edition502.0.06, 125236 bytes, downloaded2026-09-12 from the official-app-derived endpoint `http://www.baat22.com:800/nfapp/firm/1/_main5020xx.bin`. Identical to EUC World's Aero image45. SHA-256: `b2f213e4be112b343690a1676ab4a1ffed05b3fe6194d3e7dbd400a26176f7c6`. HTTP provenance and mirror match are not cryptographic manufacturer authentication.
+
+Dispatcher at file offsets0x5e86..0x5f02 loads bank2 wire14 and calls setter0x380c, which writes valid speed into configuration RAM0x20008fa4+0x35. The page8 serializer reads the same byte. Code locations here are file offsets, not assumed runtime addresses.
+
+Thus the replacement field mapping is confirmed in official Aero firmware code and independently verified from Aeon capture. It was not merely copied from another app's proposed write. This is evidence of shared NOSFET semantics, but rollout is Aeon-only: other model/version compatibility has not been established. No Aero image was flashed to Aeon.


### PR DESCRIPTION
## Summary

Closes #21.

Correct the packet used by the existing NOSFET Aeon alarm-speed control. This PR is independently based on upstream main `fac53425`; it does not include or depend on the headlight changes in #20.

- Identified Aeon wheels use a 19-byte `LdAp` bank-2 command, with speed at zero-based wire offset14.
- Other Veteran models and unknown models retain the existing 17-byte `LkAp` mapping.
- Existing model identification handles both reported names and complete telemetry frames from generic BLE names such as NF7445; reset clears command identification.
- Preserve the existing 1..99 km/h application clamp, CRC builder and single ATT write.

No UI changes, new controls, telemetry decoding changes, capability changes, headlight changes, off sentinels or legal-mode flow changes are included. Model-specific packet selection is centralized in the command builder.

## Evidence

**Verified from Aeon capture, firmware503002 (503.0.02):** the generic `LkAp` command did not change either alarm-setting readback. The replacement changed both the common-header alarm and page8 byte54 from35 → 34 → 35, including restoration and a fresh-session repeat. Tiltback remained42.

Original captured vectors, including CRC32-BE:

```text
34 km/h: 4c 64 41 70 13 01 02 80 80 80 80 80 80 80 22 e9 29 46 92
35 km/h: 4c 64 41 70 13 01 02 80 80 80 80 80 80 80 23 9e 2e 76 04
```

**Confirmed in official Aero502.0.06 firmware code:** bank2 wire14 reaches setter0x380c and the configuration field serialized into the same page8 setting. This independently corroborates the mapping, rather than relying only on another app's proposed write. Firmware endpoint, hash, file offsets and capture timestamps are documented in `docs/protocols/aeon-alarm-speed.md`.

This supports shared NOSFET semantics, but rollout is Aeon-only. Settings acceptance/readback was verified; physical alarm enforcement while riding was not. No firmware image was flashed or distributed by this PR.

## Validation

Independently run on this alarm-only branch:

```text
gradlew.bat :app:testDebugUnitTest --tests "com.eried.eucplanet.ble.*" --tests "*Legal*" --tests "*Headlight*"
143 tests passed; zero failures, errors or skips.
```

Tests cover exact original TX vectors, bounds, padding, CRC, name/captured-telemetry identification, reset, unchanged tiltback/headlight behavior and unchanged alarm mappings for other models. No APK or live wheel operation was performed for this submission.
